### PR TITLE
Test Setup for Unity3D

### DIFF
--- a/DEFCON Z/Assets/Tests.meta
+++ b/DEFCON Z/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bcff2187fee8af64a9327f64c7822b73
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DEFCON Z/Assets/Tests/EditMode Tests.meta
+++ b/DEFCON Z/Assets/Tests/EditMode Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 63ccb8565b8e54f4c93d720ade9b5f6c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DEFCON Z/Assets/Tests/EditMode Tests/EditMode Tests.asmdef
+++ b/DEFCON Z/Assets/Tests/EditMode Tests/EditMode Tests.asmdef
@@ -1,0 +1,9 @@
+﻿{
+    "name": "EditModeTests",
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ]
+}

--- a/DEFCON Z/Assets/Tests/EditMode Tests/EditMode Tests.asmdef.meta
+++ b/DEFCON Z/Assets/Tests/EditMode Tests/EditMode Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f0b7bc05aa6efd3448aadd5158fbe475
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DEFCON Z/Assets/Tests/PlayMode Tests.meta
+++ b/DEFCON Z/Assets/Tests/PlayMode Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 138ca44884e8db44f98f1ade21f4f25e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DEFCON Z/Assets/Tests/PlayMode Tests/PlayMode Tests.asmdef
+++ b/DEFCON Z/Assets/Tests/PlayMode Tests/PlayMode Tests.asmdef
@@ -1,0 +1,6 @@
+﻿{
+    "name": "PlayModeTests",
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ]
+}

--- a/DEFCON Z/Assets/Tests/PlayMode Tests/PlayMode Tests.asmdef.meta
+++ b/DEFCON Z/Assets/Tests/PlayMode Tests/PlayMode Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b003d6925e47869419f0d4567b64d539
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Description
This patch add initial setups for testing in Unity.
No actual unit tests are added. Only metadata for Unity.

## Related Issue
N/a

## Motivation and Context
This change will help in organizing, creating and testing unit tests for the project.
