### PR TITLE
Add "Left Alt" as Alternate Camera Panning Control

### DIFF
--- a/DEFCON Z/Assets/Scripts/Player/CameraController.cs
+++ b/DEFCON Z/Assets/Scripts/Player/CameraController.cs
@@ -54,7 +54,7 @@ namespace DefconZ
         private void RotateCamera()
         {
 
-            if (Input.GetKey(KeyCode.Mouse2))
+            if (Input.GetAxis("CameraRotation") != 0)
             {
                 Vector3 rotation = new Vector3(0, 0, 0);
 

--- a/DEFCON Z/ProjectSettings/InputManager.asset
+++ b/DEFCON Z/ProjectSettings/InputManager.asset
@@ -309,3 +309,19 @@ InputManager:
     type: 0
     axis: 0
     joyNum: 0
+  - serializedVersion: 3
+    m_Name: CameraRotation
+    descriptiveName: Pressing these keys allows the camera to rotate
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: mouse 2
+    altNegativeButton: 
+    altPositiveButton: left alt
+    gravity: 9999
+    dead: 0.001
+    sensitivity: 9999
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 0
+    joyNum: 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds the "left alt" key as an alternative method of panning the camera.

Implementation changes hard coding of the middle mouse button activating camera rotation to handling by the input manager axis.


## Motivation and Context
Players can now re-bind primary and alternate key bindings for camera rotation if desired.
Useful for players without a mouse, or those who prefer not to use the middle mouse button to rotate the camera.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)