### PR TITLE
Level for Faction

### DIFF
--- a/DEFCON Z/Assets/Scripts/Simulation/Level.cs
+++ b/DEFCON Z/Assets/Scripts/Simulation/Level.cs
@@ -1,0 +1,84 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace DefconZ.Simulation
+{
+    /// <summary>
+    /// The faction's level. This represents how capable the factions are.
+    /// 
+    /// There are two ways in the game to increase level.
+    /// 
+    /// 1. By gaining xp points.
+    /// 2. Trading science for Level.
+    /// 
+    /// Player increase level by gaining 100 experience point.
+    /// </summary>
+    public class Level
+    {
+        public int CurrentLevel { get; protected set; } = 0;
+        public int TotalXPEarned { get; protected set; }
+        public Modifier LevelModifier { get; }
+
+        public Level()
+        {
+            // Starting modifier for level 0.
+            LevelModifier = new Modifier
+            {
+                Name = nameof(Level),
+                Type = ModifierType.Level,
+                Value = 0.0f
+            };
+        }
+
+        /// <summary>
+        /// Adds experience point.
+        /// </summary>
+        /// <param name="xpToAdd">The xp to add.</param>
+        public void AddXP(int xpToAdd)
+        {
+            TotalXPEarned += xpToAdd;
+
+            int newLevel = TotalXPEarned / 100;
+
+            int increaseInLevel = newLevel - CurrentLevel;
+
+            if (increaseInLevel > 0)
+            {
+                IncreaseLevel(increaseInLevel);
+            }
+        }
+
+        /// <summary>
+        /// Increases the level.
+        /// </summary>
+        /// <param name="levelToIncrease">The level to increase.</param>
+        private void IncreaseLevel(int levelToIncrease)
+        {
+            for (int i = 0; i < levelToIncrease; i++)
+            {
+                IncreaseLevel();
+            }
+        }
+
+        /// <summary>
+        /// Increases the level.
+        /// </summary>
+        private void IncreaseLevel()
+        {
+            float modToIncrease = 0.0f;
+
+            if (CurrentLevel < 5)
+            {
+                modToIncrease = 0.01f;
+            } else
+            {
+                modToIncrease = 0.005f;
+            }
+
+            LevelModifier.Value += modToIncrease;
+            CurrentLevel++;
+        }
+    }
+}
+

--- a/DEFCON Z/Assets/Scripts/Simulation/Level.cs.meta
+++ b/DEFCON Z/Assets/Scripts/Simulation/Level.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3688247ad77e2f94ca24e74b25d2a4f7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DEFCON Z/Assets/Scripts/Simulation/ModifierType.cs
+++ b/DEFCON Z/Assets/Scripts/Simulation/ModifierType.cs
@@ -11,7 +11,8 @@ namespace DefconZ.Simulation
     public enum ModifierType
     {
         Event,
-        Difficulty
+        Difficulty,
+        Level
     }
 }
 

--- a/DEFCON Z/Assets/Scripts/Units/Faction.cs
+++ b/DEFCON Z/Assets/Scripts/Units/Faction.cs
@@ -12,10 +12,15 @@ namespace DefconZ.Units
         public FactionType FactionType { get; set; }
         public bool IsHumanPlayer { get; set; } = false;
         public GameObject UnitPrefab { get; internal set; }
+        public Level Level { get; set; }
 
         private void Awake()
         {
             Units = new List<GameObject>();
+            Level = new Level();
+
+            // Reference the faction level to the resource calculation.
+            Resource.Modifiers.Add(Level.LevelModifier);
         }
 
         private void Start()

--- a/DEFCON Z/Assets/Tests/PlayMode Tests/LevelTest.cs
+++ b/DEFCON Z/Assets/Tests/PlayMode Tests/LevelTest.cs
@@ -39,6 +39,7 @@ namespace Tests
         [TestCase(100, 1)]
         [TestCase(200, 2)]
         [TestCase(50, 0)]
+        [TestCase(150, 1)]
         [TestCase(1000, 10)]
         public void AddXP_Should_Increase_Level_When_XPThreshold_Reached(int xpToAdd, int expectedLevel)
         {

--- a/DEFCON Z/Assets/Tests/PlayMode Tests/LevelTest.cs
+++ b/DEFCON Z/Assets/Tests/PlayMode Tests/LevelTest.cs
@@ -1,0 +1,77 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using DefconZ.Simulation;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Tests
+{
+    public class LevelTest
+    {
+
+        /// <summary>
+        /// Tests if XP Earned is increased when added.
+        /// </summary>
+        [Test]
+        public void AddXP_Should_Increase_AmountOfXPEarned()
+        {
+            // Arrange
+            var level = new Level();
+            int expectedXp = 100;
+            int xpToAdd = 100;
+
+            // Act
+            level.AddXP(xpToAdd);
+
+
+            // Assert
+            Assert.AreEqual(expectedXp, level.TotalXPEarned);
+        }
+
+
+        /// <summary>
+        /// This tests whether the level is incremented when XP threshold
+        /// is reached. The starting level and xp is zero.
+        /// </summary>
+        /// <param name="xpToAdd">The xp to add.</param>
+        /// <param name="expectedLevel">The expected level.</param>
+        [TestCase(100, 1)]
+        [TestCase(200, 2)]
+        [TestCase(50, 0)]
+        [TestCase(1000, 10)]
+        public void AddXP_Should_Increase_Level_When_XPThreshold_Reached(int xpToAdd, int expectedLevel)
+        {
+            // Arrange
+            var level = new Level();
+
+            // Act
+            level.AddXP(xpToAdd);
+
+
+            // Assert
+            Assert.That(expectedLevel, Is.EqualTo(level.CurrentLevel));
+        }
+
+        /// <summary>
+        /// The level increase should increase modifier value appropriately.
+        /// </summary>
+        /// <param name="xpToAdd">The xp to add.</param>
+        /// <param name="expectedModValue">The expected mod value.</param>
+        [TestCase(100, 0.01f)]
+        [TestCase(500, 0.05f)]
+        [TestCase(1000, 0.075f)]
+        public void AddXp_Should_Increase_ModifierValue_Appropriately(int xpToAdd, float expectedModValue)
+        {
+            // Arrange
+            var level = new Level();
+            float margin = 0.001f;
+
+            // Act
+            level.AddXP(xpToAdd);
+
+            // Assert
+            Assert.That(expectedModValue, Is.EqualTo(level.LevelModifier.Value).Within(margin));
+        }
+    }
+}

--- a/DEFCON Z/Assets/Tests/PlayMode Tests/LevelTest.cs.meta
+++ b/DEFCON Z/Assets/Tests/PlayMode Tests/LevelTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fb0e88cb2a8131942824fc4d72ae656f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Description
Added level modifier for faction. An increase in level will increase the stats for each faction. This makes fighting off other faction easier or harder depending who levels up first. Two ways a faction can level up. By winning fights or trading Science Points. Science Points will not be implemented in Sprint 1.

## Related Issue
See #20.

## Motivation and Context
Add objective for player and make the game more challenging.

## How Has This Been Tested?
A new test has been created for this PR.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
