### PR TITLE
Change FactionOwner type to Faction

### DIFF
--- a/DEFCON Z/Assets/Scripts/GameManager.cs
+++ b/DEFCON Z/Assets/Scripts/GameManager.cs
@@ -38,7 +38,7 @@ namespace DefconZ
             humanFaction.UnitPrefab = HumanPrefab;
             humanFaction.FactionType = FactionType.Human;
             humanFaction.FactionName = "Human Player";
-            humanFaction.IsHumanPlayer = true;
+            humanFaction.IsPlayerUnit = true;
 
             var humanUnit = Instantiate(HumanPrefab, new Vector3(-1.90f, 0.0f, -36.0f), Quaternion.identity);
             humanUnit.GetComponent<Human>().FactionOwner = humanFaction;

--- a/DEFCON Z/Assets/Scripts/GameManager.cs
+++ b/DEFCON Z/Assets/Scripts/GameManager.cs
@@ -41,7 +41,7 @@ namespace DefconZ
             humanFaction.IsHumanPlayer = true;
 
             var humanUnit = Instantiate(HumanPrefab, new Vector3(-1.90f, 0.0f, -36.0f), Quaternion.identity);
-            humanUnit.GetComponent<Human>().FactionOwner = humanFaction.FactionName;
+            humanUnit.GetComponent<Human>().FactionOwner = humanFaction;
 
             humanFaction.Units.Add(humanUnit);
 
@@ -55,7 +55,7 @@ namespace DefconZ
             zombieFaction.FactionName = "Zombie AI";
 
             var zombieUnit = Instantiate(ZombiePrefab, new Vector3(17.24f, 0.0f, -33.95f), Quaternion.identity);
-            zombieUnit.GetComponent<Human>().FactionOwner = zombieFaction.FactionName;
+            zombieUnit.GetComponent<Human>().FactionOwner = zombieFaction;
 
 
 

--- a/DEFCON Z/Assets/Scripts/Units/Faction.cs
+++ b/DEFCON Z/Assets/Scripts/Units/Faction.cs
@@ -10,7 +10,7 @@ namespace DefconZ.Units
         public Resource Resource { get; set; }
         public IList<GameObject> Units { get; set; }
         public FactionType FactionType { get; set; }
-        public bool IsHumanPlayer { get; set; } = false;
+        public bool IsPlayerUnit { get; set; } = false;
         public GameObject UnitPrefab { get; internal set; }
         public Level Level { get; set; }
 

--- a/DEFCON Z/Assets/Scripts/Units/UnitBase.cs
+++ b/DEFCON Z/Assets/Scripts/Units/UnitBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using DefconZ.Units;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.AI;
@@ -11,7 +12,7 @@ namespace DefconZ
 
         private Vector3 targetPosition;
         private NavMeshAgent navMeshAgent;
-        public string FactionOwner { get; set; }
+        public Faction FactionOwner { get; set; }
 
         // Start is called before the first frame update
         public void Start()


### PR DESCRIPTION
## Description
This PR changes FactionOwner type from `String` to `Faction` and refactor `IsHumanPlayer` to `IsPlayerUnit` to prevent ambiguity.

## Motivation and Context
This bypasses the need to manually search for the reference to the actual `Faction`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
