### PR TITLE
Resource Initialization Fix

### DIFF
--- a/DEFCON Z/Assets/Scripts/Units/Faction.cs
+++ b/DEFCON Z/Assets/Scripts/Units/Faction.cs
@@ -19,12 +19,6 @@ namespace DefconZ.Units
             Units = new List<GameObject>();
             Level = new Level();
 
-            // Reference the faction level to the resource calculation.
-            Resource.Modifiers.Add(Level.LevelModifier);
-        }
-
-        private void Start()
-        {
             Resource = new Resource();
 
             Resource.CalculateMaxPoints();
@@ -32,6 +26,12 @@ namespace DefconZ.Units
 
             Debug.Log(FactionName + " faction has Max Resource Point of " + Resource.MaxResourcePoint);
             Debug.Log(FactionName + " faction has Starting Resource Point of " + Resource.ResourcePoint);
+        }
+
+        private void Start()
+        {
+            // Reference the faction level to the resource calculation.
+            Resource.Modifiers.Add(Level.LevelModifier);
         }
     }
 }

--- a/DEFCON Z/Assets/Scripts/Units/Faction.cs
+++ b/DEFCON Z/Assets/Scripts/Units/Faction.cs
@@ -18,20 +18,19 @@ namespace DefconZ.Units
         {
             Units = new List<GameObject>();
             Level = new Level();
-
             Resource = new Resource();
-
-            Resource.CalculateMaxPoints();
-            Resource.ComputeStartingValue();
-
-            Debug.Log(FactionName + " faction has Max Resource Point of " + Resource.MaxResourcePoint);
-            Debug.Log(FactionName + " faction has Starting Resource Point of " + Resource.ResourcePoint);
         }
 
         private void Start()
         {
             // Reference the faction level to the resource calculation.
             Resource.Modifiers.Add(Level.LevelModifier);
+
+            Resource.CalculateMaxPoints();
+            Resource.ComputeStartingValue();
+
+            Debug.Log(FactionName + " faction has Max Resource Point of " + Resource.MaxResourcePoint);
+            Debug.Log(FactionName + " faction has Starting Resource Point of " + Resource.ResourcePoint);
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Resource field initialization moved to Awake().
Resource post initialization code placed in Start().

## Motivation and Context
Resource was not being initialized before being referenced.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)