### PR TITLE
Implement Player Controlled Unit Check

### DIFF
--- a/DEFCON Z/Assets/Scripts/Player/Player.cs
+++ b/DEFCON Z/Assets/Scripts/Player/Player.cs
@@ -54,28 +54,39 @@ namespace DefconZ
 
         public void SelectedObjectAction()
         {
+            // Check if the player has selected a unit
             if (selectedObject != null)
             {
+                // Check if the selected object is a unit
                 UnitBase _selectedUnit = selectedObject.GetComponent<UnitBase>();
                 if (_selectedUnit != null)
                 {
-                    // at this point we know the object can accept an order
-                    // raycast for the order location
-                    RaycastHit _rayCastHit = new RaycastHit();
-
-                    // check that the player has clicked somewhere
-                    if (Physics.Raycast(cam.ScreenPointToRay(Input.mousePosition), out _rayCastHit))
+                    // Check if the selected unit is owned by the player
+                    if (_selectedUnit.FactionOwner.IsPlayerUnit)
                     {
-                        if (_rayCastHit.transform.gameObject.GetComponent<UnitBase>() != null)
+                        Debug.Log("Selected unit is a player controlled unit");
+                        // at this point we know the object can accept an order
+                        // raycast for the order location
+                        RaycastHit _rayCastHit = new RaycastHit();
+
+                        // check that the player has clicked somewhere
+                        if (Physics.Raycast(cam.ScreenPointToRay(Input.mousePosition), out _rayCastHit))
                         {
-                            Debug.Log("Hit another unit");
-							_selectedUnit.StartAttack(_rayCastHit.transform.gameObject);
-                        } else
-                        {
-                            _selectedUnit.MoveTo(_rayCastHit.point);
-                            Debug.Log("Clicked move position");
+                            if (_rayCastHit.transform.gameObject.GetComponent<UnitBase>() != null)
+                            {
+                                Debug.Log("Hit another unit");
+                                _selectedUnit.StartAttack(_rayCastHit.transform.gameObject);
+                            }
+                            else
+                            {
+                                _selectedUnit.MoveTo(_rayCastHit.point);
+                                Debug.Log("Clicked move position");
+                            }
                         }
-                    } 
+                    } else
+                    {
+                        Debug.Log("Selected unit is not player controlled, cannot give orders");
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Description
Adds a check to make sure the selected unit is player controlled before issuing an order.

## Related Issue
Closes #22 

## Motivation and Context
Players should not be able to give orders to units they do not control.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
