### PR TITLE
Unit Recruitment

### DIFF
--- a/DEFCON Z/Assets/Prefabs/Units/Human.prefab
+++ b/DEFCON Z/Assets/Prefabs/Units/Human.prefab
@@ -52,8 +52,8 @@ MonoBehaviour:
   objName: Survivor
   health: 100
   deathSound: {fileID: 8300000, guid: beca4447c7e7c5e4f994c4c88a5e04f9, type: 3}
-  RecruitCost: 1000
-  Upkeep: 5
+  RecruitCost: 500
+  Upkeep: 0.5
   navMeshAgent: {fileID: 0}
   audioSource: {fileID: 0}
 --- !u!136 &6112589138305832952

--- a/DEFCON Z/Assets/Prefabs/Units/Human.prefab
+++ b/DEFCON Z/Assets/Prefabs/Units/Human.prefab
@@ -52,6 +52,7 @@ MonoBehaviour:
   objName: Survivor
   health: 100
   deathSound: {fileID: 8300000, guid: beca4447c7e7c5e4f994c4c88a5e04f9, type: 3}
+  RecruitCost: 1000
   Upkeep: 5
   navMeshAgent: {fileID: 0}
   audioSource: {fileID: 0}

--- a/DEFCON Z/Assets/Prefabs/Units/Human.prefab
+++ b/DEFCON Z/Assets/Prefabs/Units/Human.prefab
@@ -52,6 +52,7 @@ MonoBehaviour:
   objName: Survivor
   health: 100
   deathSound: {fileID: 8300000, guid: beca4447c7e7c5e4f994c4c88a5e04f9, type: 3}
+  Upkeep: 5
   navMeshAgent: {fileID: 0}
   audioSource: {fileID: 0}
 --- !u!136 &6112589138305832952

--- a/DEFCON Z/Assets/Prefabs/Units/Zombie.prefab
+++ b/DEFCON Z/Assets/Prefabs/Units/Zombie.prefab
@@ -51,6 +51,7 @@ MonoBehaviour:
   objName: Zombie
   health: 100
   deathSound: {fileID: 8300000, guid: beca4447c7e7c5e4f994c4c88a5e04f9, type: 3}
+  Upkeep: 5
   navMeshAgent: {fileID: 0}
   audioSource: {fileID: 0}
 --- !u!136 &6693292440879736203

--- a/DEFCON Z/Assets/Prefabs/Units/Zombie.prefab
+++ b/DEFCON Z/Assets/Prefabs/Units/Zombie.prefab
@@ -52,7 +52,7 @@ MonoBehaviour:
   health: 100
   deathSound: {fileID: 8300000, guid: beca4447c7e7c5e4f994c4c88a5e04f9, type: 3}
   RecruitCost: 500
-  Upkeep: 5
+  Upkeep: 0.5
   navMeshAgent: {fileID: 0}
   audioSource: {fileID: 0}
 --- !u!136 &6693292440879736203

--- a/DEFCON Z/Assets/Prefabs/Units/Zombie.prefab
+++ b/DEFCON Z/Assets/Prefabs/Units/Zombie.prefab
@@ -51,6 +51,7 @@ MonoBehaviour:
   objName: Zombie
   health: 100
   deathSound: {fileID: 8300000, guid: beca4447c7e7c5e4f994c4c88a5e04f9, type: 3}
+  RecruitCost: 500
   Upkeep: 5
   navMeshAgent: {fileID: 0}
   audioSource: {fileID: 0}

--- a/DEFCON Z/Assets/Scenes/SimulationDevScene.unity
+++ b/DEFCON Z/Assets/Scenes/SimulationDevScene.unity
@@ -2556,6 +2556,36 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1347539061}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1404108771
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1404108772}
+  m_Layer: 0
+  m_Name: HumanSpawnPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1404108772
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1404108771}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -31.8}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1418744534
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3210,6 +3240,36 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &1808157723
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1808157724}
+  m_Layer: 0
+  m_Name: ZombieSpawnPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1808157724
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1808157723}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 17.58, y: 0, z: -33.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &1839446661 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4699883680798423777, guid: ea96661379946524885f1bf702f94484,

--- a/DEFCON Z/Assets/Scenes/SimulationDevScene.unity
+++ b/DEFCON Z/Assets/Scenes/SimulationDevScene.unity
@@ -1318,6 +1318,7 @@ GameObject:
   - component: {fileID: 772773001}
   - component: {fileID: 772773000}
   - component: {fileID: 772773002}
+  - component: {fileID: 772773003}
   m_Layer: 0
   m_Name: GameManager
   m_TagString: Untagged
@@ -1338,10 +1339,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Factions: []
-  HumanPrefab: {fileID: 6112589138305832958, guid: d93bba217fb07e6439ab29855d7ac1af,
-    type: 3}
-  ZombiePrefab: {fileID: 6693292440879736205, guid: 963bbb3a5efe1e449a948a22d4b086e1,
-    type: 3}
+  HumanSpawnPoint: {fileID: 0}
+  ZombieSpawnPoint: {fileID: 0}
 --- !u!4 &772773001
 Transform:
   m_ObjectHideFlags: 0
@@ -1368,6 +1367,20 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 862d458cb6a7e744d8aa71e762971b31, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &772773003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 772772999}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 03f6f2274e6189d4495860aabf83d0ce, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Human: {fileID: 6112589138305832958, guid: d93bba217fb07e6439ab29855d7ac1af, type: 3}
+  Zombie: {fileID: 6693292440879736205, guid: 963bbb3a5efe1e449a948a22d4b086e1, type: 3}
 --- !u!1001 &802851758
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/DEFCON Z/Assets/Scripts/GameManager.cs
+++ b/DEFCON Z/Assets/Scripts/GameManager.cs
@@ -36,7 +36,7 @@ namespace DefconZ
         // Start is called before the first frame update
         private void Start()
         {
-            var humanFaction = gameObject.AddComponent<Faction>();
+            var humanFaction = gameObject.AddComponent<HumanFaction>();
 
             humanFaction.UnitPrefab = UnitPrefabList.Instance.Human;
             humanFaction.FactionType = FactionType.Human;
@@ -51,6 +51,7 @@ namespace DefconZ
             Factions.Add(humanFaction);
 
             var zombieFaction = gameObject.AddComponent<Faction>();
+            var zombieFaction = gameObject.AddComponent<ZombieFaction>();
 
             zombieFaction.UnitPrefab = UnitPrefabList.Instance.Zombie;
             zombieFaction.FactionType = FactionType.Zombie;

--- a/DEFCON Z/Assets/Scripts/GameManager.cs
+++ b/DEFCON Z/Assets/Scripts/GameManager.cs
@@ -97,7 +97,13 @@ namespace DefconZ
             foreach (var faction in Factions)
             {
                 Debug.Log($"Gathering resource for {faction.FactionName}");
-                faction.Resource.GatherResource();
+                var resourceGathered = faction.Resource.GatherResource();
+                var maintenanceCost = faction.MaintainUnit();
+
+                Debug.Log($"Gathered {resourceGathered} amount of resource.");
+                Debug.Log($"Maintenance cost at {maintenanceCost}");
+
+                Debug.Log($"{faction.FactionName} has {faction.Resource.ResourcePoint} amount of resources.");
             }
 
             Debug.Log("Game day elapsed " + Clock.Instance.GameDay);

--- a/DEFCON Z/Assets/Scripts/GameManager.cs
+++ b/DEFCON Z/Assets/Scripts/GameManager.cs
@@ -43,30 +43,17 @@ namespace DefconZ
             humanFaction.FactionName = "Human Player";
             humanFaction.IsPlayerUnit = true;
 
-            var humanUnit = Instantiate(humanFaction.UnitPrefab, new Vector3(-1.90f, 0.0f, -36.0f), Quaternion.identity);
-            humanUnit.GetComponent<Human>().FactionOwner = humanFaction;
-
-            humanFaction.Units.Add(humanUnit);
-
-            Factions.Add(humanFaction);
-
-            var zombieFaction = gameObject.AddComponent<Faction>();
             var zombieFaction = gameObject.AddComponent<ZombieFaction>();
 
             zombieFaction.UnitPrefab = UnitPrefabList.Instance.Zombie;
             zombieFaction.FactionType = FactionType.Zombie;
             zombieFaction.FactionName = "Zombie AI";
 
-            var zombieUnit = Instantiate(zombieFaction.UnitPrefab, new Vector3(17.24f, 0.0f, -33.95f), Quaternion.identity);
-            var zombieUnit2 = Instantiate(zombieFaction.UnitPrefab, new Vector3(10.24f, 0.0f, -33.95f), Quaternion.identity);
-            zombieUnit.GetComponent<Zombie>().FactionOwner = zombieFaction;
-            zombieUnit2.GetComponent<Zombie>().FactionOwner = zombieFaction;
-            zombieUnit2.GetComponent<Zombie>().objName = "Zombie2";
-
-            zombieFaction.Units.Add(zombieUnit);
-            zombieFaction.Units.Add(zombieUnit2);
-
+            Factions.Add(humanFaction);
             Factions.Add(zombieFaction);
+
+            humanFaction.RecruitUnit();
+            zombieFaction.RecruitUnit();
 
             var clock = Clock.Instance;
 

--- a/DEFCON Z/Assets/Scripts/GameManager.cs
+++ b/DEFCON Z/Assets/Scripts/GameManager.cs
@@ -87,6 +87,11 @@ namespace DefconZ
             }
         }
 
+        /// <summary>
+        /// Occurs when a game day has passed.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="System.EventArgs"/> instance containing the event data.</param>
         private void Clock_GameCycleElapsed(object sender, System.EventArgs e)
         {
             foreach (var faction in Factions)

--- a/DEFCON Z/Assets/Scripts/GameManager.cs
+++ b/DEFCON Z/Assets/Scripts/GameManager.cs
@@ -16,8 +16,6 @@ namespace DefconZ
         /// </summary>
         public List<Faction> Factions;
 
-        public GameObject HumanPrefab;
-        public GameObject ZombiePrefab;
         public IDictionary<Guid, Combat> ActiveCombats;
 
         private void Awake()
@@ -40,12 +38,12 @@ namespace DefconZ
         {
             var humanFaction = gameObject.AddComponent<Faction>();
 
-            humanFaction.UnitPrefab = HumanPrefab;
+            humanFaction.UnitPrefab = UnitPrefabList.Instance.Human;
             humanFaction.FactionType = FactionType.Human;
             humanFaction.FactionName = "Human Player";
             humanFaction.IsPlayerUnit = true;
 
-            var humanUnit = Instantiate(HumanPrefab, new Vector3(-1.90f, 0.0f, -36.0f), Quaternion.identity);
+            var humanUnit = Instantiate(humanFaction.UnitPrefab, new Vector3(-1.90f, 0.0f, -36.0f), Quaternion.identity);
             humanUnit.GetComponent<Human>().FactionOwner = humanFaction;
 
             humanFaction.Units.Add(humanUnit);
@@ -54,12 +52,12 @@ namespace DefconZ
 
             var zombieFaction = gameObject.AddComponent<Faction>();
 
-            zombieFaction.UnitPrefab = ZombiePrefab;
+            zombieFaction.UnitPrefab = UnitPrefabList.Instance.Zombie;
             zombieFaction.FactionType = FactionType.Zombie;
             zombieFaction.FactionName = "Zombie AI";
 
-            var zombieUnit = Instantiate(ZombiePrefab, new Vector3(17.24f, 0.0f, -33.95f), Quaternion.identity);
-            var zombieUnit2 = Instantiate(ZombiePrefab, new Vector3(10.24f, 0.0f, -33.95f), Quaternion.identity);
+            var zombieUnit = Instantiate(zombieFaction.UnitPrefab, new Vector3(17.24f, 0.0f, -33.95f), Quaternion.identity);
+            var zombieUnit2 = Instantiate(zombieFaction.UnitPrefab, new Vector3(10.24f, 0.0f, -33.95f), Quaternion.identity);
             zombieUnit.GetComponent<Zombie>().FactionOwner = zombieFaction;
             zombieUnit2.GetComponent<Zombie>().FactionOwner = zombieFaction;
             zombieUnit2.GetComponent<Zombie>().objName = "Zombie2";

--- a/DEFCON Z/Assets/Scripts/Simulation/Resource.cs
+++ b/DEFCON Z/Assets/Scripts/Simulation/Resource.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
@@ -71,8 +72,8 @@ namespace DefconZ.Simulation
         /// <summary>
         /// Computes the gain/loss in resources.
         /// </summary>
-        /// <exception cref="System.NotImplementedException"></exception>
-        public void GatherResource()
+        /// <returns>Resource gathered</returns>
+        public float GatherResource()
         {
             // Base resource replenish resource point from zero to full in
             // 3 years or 1095 days.
@@ -88,7 +89,7 @@ namespace DefconZ.Simulation
                 ResourcePoint = MaxResourcePoint;
             }
 
-            Debug.Log($"Resource point increased by {resourcePointIncrease} to {ResourcePoint}");
+            return resourcePointIncrease;
         }
 
         /// <summary>

--- a/DEFCON Z/Assets/Scripts/Simulation/Resource.cs
+++ b/DEFCON Z/Assets/Scripts/Simulation/Resource.cs
@@ -90,5 +90,14 @@ namespace DefconZ.Simulation
 
             Debug.Log($"Resource point increased by {resourcePointIncrease} to {ResourcePoint}");
         }
+
+        /// <summary>
+        /// Uses the resource.
+        /// </summary>
+        /// <param name="resourceToUse">The amount of resource to use.</param>
+        public void UseResource(float resourceToUse)
+        {
+            ResourcePoint -= resourceToUse;
+        }
     }
 }

--- a/DEFCON Z/Assets/Scripts/Units/Faction.cs
+++ b/DEFCON Z/Assets/Scripts/Units/Faction.cs
@@ -20,11 +20,7 @@ namespace DefconZ.Units
             Units = new List<GameObject>();
             Level = new Level();
             Resource = new Resource();
-            InitAwake();
-        }
 
-        private void Start()
-        {
             // Reference the faction level to the resource calculation.
             Resource.Modifiers.Add(Level.LevelModifier);
 
@@ -34,6 +30,11 @@ namespace DefconZ.Units
             Debug.Log(FactionName + " faction has Max Resource Point of " + Resource.MaxResourcePoint);
             Debug.Log(FactionName + " faction has Starting Resource Point of " + Resource.ResourcePoint);
 
+            InitAwake();
+        }
+
+        private void Start()
+        {
             InitStart();
         }
 

--- a/DEFCON Z/Assets/Scripts/Units/Faction.cs
+++ b/DEFCON Z/Assets/Scripts/Units/Faction.cs
@@ -20,6 +20,7 @@ namespace DefconZ.Units
             Units = new List<GameObject>();
             Level = new Level();
             Resource = new Resource();
+            InitAwake();
         }
 
         private void Start()
@@ -34,6 +35,13 @@ namespace DefconZ.Units
             Debug.Log(FactionName + " faction has Starting Resource Point of " + Resource.ResourcePoint);
 
             InitStart();
+        }
+
+        /// <summary>
+        /// Initializes this instance.
+        /// </summary>
+        protected virtual void InitAwake()
+        {
         }
 
         /// <summary>

--- a/DEFCON Z/Assets/Scripts/Units/Faction.cs
+++ b/DEFCON Z/Assets/Scripts/Units/Faction.cs
@@ -13,6 +13,7 @@ namespace DefconZ.Units
         public bool IsPlayerUnit { get; set; } = false;
         public GameObject UnitPrefab { get; internal set; }
         public Level Level { get; set; }
+        public GameObject UnitSpawnPoint;
 
         private void Awake()
         {

--- a/DEFCON Z/Assets/Scripts/Units/Faction.cs
+++ b/DEFCON Z/Assets/Scripts/Units/Faction.cs
@@ -32,6 +32,17 @@ namespace DefconZ.Units
 
             Debug.Log(FactionName + " faction has Max Resource Point of " + Resource.MaxResourcePoint);
             Debug.Log(FactionName + " faction has Starting Resource Point of " + Resource.ResourcePoint);
+
+            InitStart();
+        }
+
+        /// <summary>
+        /// Initializes this instance when Start is called or when game object
+        /// is active.
+        /// </summary>
+        protected virtual void InitStart()
+        {
+        }
         }
     }
 }

--- a/DEFCON Z/Assets/Scripts/Units/Faction.cs
+++ b/DEFCON Z/Assets/Scripts/Units/Faction.cs
@@ -43,6 +43,27 @@ namespace DefconZ.Units
         protected virtual void InitStart()
         {
         }
+        /// <summary>
+        /// Determines whether this faction has enough resource point to
+        /// recruit a unit.
+        /// </summary>
+        /// <returns>
+        ///   <c>true</c> if this faction [can recruit unit]; otherwise, <c>false</c>.
+        /// </returns>
+        public bool CanRecruitUnit()
+        {
+            bool canRecruitUnit = UnitPrefab.GetComponent<UnitBase>().RecruitCost <= Resource.ResourcePoint;
+
+            if (canRecruitUnit)
+            {
+                Debug.Log(this.FactionName + " have enough point to recruit new unit");
+            }
+            else
+            {
+                Debug.Log(FactionName + " don't have enough point to recruit new unit");
+            }
+
+            return canRecruitUnit;
         }
     }
 }

--- a/DEFCON Z/Assets/Scripts/Units/Faction.cs
+++ b/DEFCON Z/Assets/Scripts/Units/Faction.cs
@@ -43,6 +43,26 @@ namespace DefconZ.Units
         protected virtual void InitStart()
         {
         }
+
+        /// <summary>
+        /// Recruits a new unit when there is enough resource for the
+        /// faction.
+        /// </summary>
+        public void RecruitUnit()
+        {
+            if (CanRecruitUnit())
+            {
+                // Create the unit.
+                var newUnit = Instantiate(UnitPrefab, UnitSpawnPoint.transform.position, Quaternion.identity);
+                newUnit.GetComponent<UnitBase>().FactionOwner = this;
+
+                // Consume the resource when creating.
+                Resource.UseResource(newUnit.GetComponent<UnitBase>().RecruitCost);
+
+                Units.Add(newUnit);
+            }
+        }
+
         /// <summary>
         /// Determines whether this faction has enough resource point to
         /// recruit a unit.

--- a/DEFCON Z/Assets/Scripts/Units/Faction.cs
+++ b/DEFCON Z/Assets/Scripts/Units/Faction.cs
@@ -93,5 +93,23 @@ namespace DefconZ.Units
 
             return canRecruitUnit;
         }
+
+        /// <summary>
+        /// Maintains the unit.
+        /// </summary>
+        /// <returns></returns>
+        public float MaintainUnit()
+        {
+            var cost = 0.0f;
+
+            foreach (var unitObj in Units)
+            {
+                var upkeep = unitObj.GetComponent<UnitBase>().Upkeep;
+                Resource.UseResource(upkeep);
+                cost += upkeep;
+            }
+
+            return cost;
+        }
     }
 }

--- a/DEFCON Z/Assets/Scripts/Units/Human.cs
+++ b/DEFCON Z/Assets/Scripts/Units/Human.cs
@@ -1,14 +1,13 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-
-namespace DefconZ
+﻿namespace DefconZ
 {
     public class Human : UnitBase
     {
-        public override void InitUnit() { }
+        public override void InitUnit()
+        {
+        }
 
-        public override void Update() { }
+        public override void Update()
+        {
+        }
     }
 }
-

--- a/DEFCON Z/Assets/Scripts/Units/HumanFaction.cs
+++ b/DEFCON Z/Assets/Scripts/Units/HumanFaction.cs
@@ -4,9 +4,9 @@ namespace DefconZ.Units
 {
     public class HumanFaction : Faction
     {
-        protected override void InitStart()
+        protected override void InitAwake()
         {
-            base.InitStart();
+            base.InitAwake();
 
             UnitSpawnPoint = GameObject.Find("HumanSpawnPoint");
         }

--- a/DEFCON Z/Assets/Scripts/Units/HumanFaction.cs
+++ b/DEFCON Z/Assets/Scripts/Units/HumanFaction.cs
@@ -1,0 +1,14 @@
+﻿using UnityEngine;
+
+namespace DefconZ.Units
+{
+    public class HumanFaction : Faction
+    {
+        protected override void InitStart()
+        {
+            base.InitStart();
+
+            UnitSpawnPoint = GameObject.Find("HumanSpawnPoint");
+        }
+    }
+}

--- a/DEFCON Z/Assets/Scripts/Units/HumanFaction.cs.meta
+++ b/DEFCON Z/Assets/Scripts/Units/HumanFaction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f4168fe0293812448a63ce414db6e4e8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DEFCON Z/Assets/Scripts/Units/UnitBase.cs
+++ b/DEFCON Z/Assets/Scripts/Units/UnitBase.cs
@@ -11,11 +11,15 @@ namespace DefconZ
     {
         public float health = 100;
         public Faction FactionOwner { get; set; }
-        public Combat CurrentCombat; private Vector3 targetPosition;
+        public Combat CurrentCombat;
+        private Vector3 targetPosition;
         public AudioClip deathSound;
+        public float RecruitCost;
+        public float Upkeep;
 
         [SerializeField]
         private NavMeshAgent navMeshAgent;
+
         [SerializeField]
         private AudioSource audioSource;
 

--- a/DEFCON Z/Assets/Scripts/Units/UnitPrefabList.cs
+++ b/DEFCON Z/Assets/Scripts/Units/UnitPrefabList.cs
@@ -1,24 +1,27 @@
 ﻿using UnityEngine;
 
-public class UnitPrefabList : MonoBehaviour
+namespace DefconZ.Units
 {
-    public static UnitPrefabList Instance = null;
-
-    public GameObject Human;
-    public GameObject Zombie;
-
-    /// <summary>
-    /// Awakes this instance.
-    /// </summary>
-    private void Awake()
+    public class UnitPrefabList : MonoBehaviour
     {
-        if (Instance == null)
+        public static UnitPrefabList Instance = null;
+
+        public GameObject Human;
+        public GameObject Zombie;
+
+        /// <summary>
+        /// Awakes this instance.
+        /// </summary>
+        private void Awake()
         {
-            Instance = this;
-        }
-        else if (Instance != this)
-        {
-            Destroy(gameObject);
+            if (Instance == null)
+            {
+                Instance = this;
+            }
+            else if (Instance != this)
+            {
+                Destroy(gameObject);
+            }
         }
     }
 }

--- a/DEFCON Z/Assets/Scripts/Units/UnitPrefabList.cs
+++ b/DEFCON Z/Assets/Scripts/Units/UnitPrefabList.cs
@@ -1,0 +1,24 @@
+﻿using UnityEngine;
+
+public class UnitPrefabList : MonoBehaviour
+{
+    public static UnitPrefabList Instance = null;
+
+    public GameObject Human;
+    public GameObject Zombie;
+
+    /// <summary>
+    /// Awakes this instance.
+    /// </summary>
+    private void Awake()
+    {
+        if (Instance == null)
+        {
+            Instance = this;
+        }
+        else if (Instance != this)
+        {
+            Destroy(gameObject);
+        }
+    }
+}

--- a/DEFCON Z/Assets/Scripts/Units/UnitPrefabList.cs.meta
+++ b/DEFCON Z/Assets/Scripts/Units/UnitPrefabList.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 03f6f2274e6189d4495860aabf83d0ce
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DEFCON Z/Assets/Scripts/Units/ZombieFaction.cs
+++ b/DEFCON Z/Assets/Scripts/Units/ZombieFaction.cs
@@ -1,0 +1,14 @@
+﻿using UnityEngine;
+
+namespace DefconZ.Units
+{
+    public class ZombieFaction : Faction
+    {
+        protected override void InitStart()
+        {
+            base.InitStart();
+
+            UnitSpawnPoint = GameObject.Find("ZombieSpawnPoint");
+        }
+    }
+}

--- a/DEFCON Z/Assets/Scripts/Units/ZombieFaction.cs
+++ b/DEFCON Z/Assets/Scripts/Units/ZombieFaction.cs
@@ -4,9 +4,9 @@ namespace DefconZ.Units
 {
     public class ZombieFaction : Faction
     {
-        protected override void InitStart()
+        protected override void InitAwake()
         {
-            base.InitStart();
+            base.InitAwake();
 
             UnitSpawnPoint = GameObject.Find("ZombieSpawnPoint");
         }

--- a/DEFCON Z/Assets/Scripts/Units/ZombieFaction.cs.meta
+++ b/DEFCON Z/Assets/Scripts/Units/ZombieFaction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7e43b7a6e85c2bd44906a83c64ce7b88
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Description
Add basic unit recruitment and unit maintenance. 

This PR:
- Moves the prefab initialization to a separate script `UnitPrefabList`.
- Initialize Upkeep and Recruit Cost in respective Unit Prefab.
- Implement Maintenance to faction.
- Create the ability to recruit new unit spawn in a designated place.
- Create `HumanFaction` and `ZombieFaction`.

## Related Issue
Closes #26.

## Motivation and Context
So player and AI can both recruit unit to achieve their agenda.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
