### PR TITLE
Enable Mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,12 @@
+pull_request_rules:
+  - name: Automatic Merge to staging branch after approval.
+    conditions:
+      - "#approved-reviews-by>=1"
+      - label=ready to merge
+      - label!=work in progress
+      - status-success=CodeFactor
+      - status-success=WIP
+      - base~=sprint[0-9]*-staging
+    actions:
+      merge:
+        method: merge

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,6 +2,9 @@ pull_request_rules:
   - name: Automatic Merge to staging branch after approval.
     conditions:
       - "#approved-reviews-by>=1"
+      - "#review-requested=0"
+      - "#changes-requested-reviews-by=0"
+      - "#commented-reviews-by=0"
       - label=ready to merge
       - label!=work in progress
       - status-success=CodeFactor


### PR DESCRIPTION
## Description
Configure Mergify. Automatic merging bot.

## Motivation and Context
This allows PR author to automatically merge their request after being approved. This reduce the need for PR authors to come back to their PR to do merging. We in general only let the PR author to merge the changes when it is approved.

The criteria for auto merging is when a PR is has all of the following
- "ready to merge" label
- at least one approval 
- all status checks passes
- base branch of sprint-staging

The bot will not auto merge if none of those criteria is fulfilled.

I also created a new label "work in progress" to explicitly block auto merging even when it is approved. The author can also tagged the title with "WIP" keyword as before and the bot will honor it.

