### PR TITLE
Fix null when unit destroyed

### DIFF
--- a/DEFCON Z/Assets/Scripts/Units/Faction.cs
+++ b/DEFCON Z/Assets/Scripts/Units/Faction.cs
@@ -108,11 +108,18 @@ namespace DefconZ.Units
         {
             var cost = 0.0f;
 
-            foreach (var unitObj in Units)
+            for (int i = Units.Count - 1; i >= 0; i--)
             {
-                var upkeep = unitObj.GetComponent<UnitBase>().Upkeep;
-                Resource.UseResource(upkeep);
-                cost += upkeep;
+                if (Units[i] == null)
+                {
+                    Units.RemoveAt(i);
+                }
+                else
+                {
+                    var upkeep = Units[i].GetComponent<UnitBase>().Upkeep;
+                    Resource.UseResource(upkeep);
+                    cost += upkeep;
+                }
             }
 
             return cost;

--- a/DEFCON Z/Assets/Scripts/Units/Faction.cs
+++ b/DEFCON Z/Assets/Scripts/Units/Faction.cs
@@ -103,7 +103,7 @@ namespace DefconZ.Units
         /// <summary>
         /// Maintains the unit.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>Total cost of maintaining the unit(s).</returns>
         public float MaintainUnit()
         {
             var cost = 0.0f;

--- a/DEFCON Z/Assets/Tests/PlayMode Tests/FactionTest.cs
+++ b/DEFCON Z/Assets/Tests/PlayMode Tests/FactionTest.cs
@@ -1,6 +1,7 @@
 ﻿using DefconZ;
 using DefconZ.Units;
 using NUnit.Framework;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Tests
@@ -102,6 +103,55 @@ namespace Tests
 
             // Assert
             Assert.That(Faction.Resource.ResourcePoint, Is.EqualTo(expectedEndResource));
+        }
+
+        [Test]
+        public void MaintainUnit_Should_Remove_Destroyed_Unit_From_List()
+        {
+            // Arrange
+            int maxUnitToGenerate = 11;
+
+            for (int i = 0; i < maxUnitToGenerate; i++)
+            {
+                var unit = new GameObject();
+                unit.AddComponent<Human>();
+
+                Faction.Units.Add(unit);
+            }
+
+            // Act
+            // Destroy units that is even in the index position
+            for (int i = 0; i < maxUnitToGenerate; i++)
+            {
+                if (i % 2 == 0)
+                {
+                    Object.DestroyImmediate(Faction.Units[i].gameObject);
+                }
+            }
+
+            Faction.MaintainUnit();
+
+            // Assert
+            Assert.That(Faction.Units.Count, Is.EqualTo(maxUnitToGenerate / 2));
+        }
+
+        [Test]
+        public void MaintainUnit_Should_Not_Throw_Null()
+        {
+            // Arrange
+            var unit = new GameObject();
+            unit.AddComponent<Human>();
+
+            Faction.Units.Add(unit);
+
+            // Act
+            // Destroy units that is even in the index position
+            Object.DestroyImmediate(Faction.Units[0].gameObject);
+
+
+
+            // Assert
+            Assert.DoesNotThrow(() => Faction.MaintainUnit());
         }
     }
 }

--- a/DEFCON Z/Assets/Tests/PlayMode Tests/FactionTest.cs
+++ b/DEFCON Z/Assets/Tests/PlayMode Tests/FactionTest.cs
@@ -6,9 +6,8 @@ using UnityEngine;
 namespace Tests
 {
     [TestFixture]
-    public class FactionTest
+    public class FactionTest : BaseTest
     {
-        private GameObject FactionObject;
         private Faction Faction;
 
         /// <summary>
@@ -17,8 +16,7 @@ namespace Tests
         [SetUp]
         public void TestInit()
         {
-            FactionObject = new GameObject();
-            Faction = FactionObject.AddComponent<Faction>();
+            Faction = _gameObject.AddComponent<Faction>();
         }
 
         /// <summary>
@@ -27,7 +25,6 @@ namespace Tests
         [TearDown]
         public void TestCleanup()
         {
-            FactionObject = null;
             Faction = null;
         }
 

--- a/DEFCON Z/Assets/Tests/PlayMode Tests/FactionTest.cs
+++ b/DEFCON Z/Assets/Tests/PlayMode Tests/FactionTest.cs
@@ -1,7 +1,6 @@
 ﻿using DefconZ;
 using DefconZ.Units;
 using NUnit.Framework;
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace Tests
@@ -109,7 +108,7 @@ namespace Tests
         public void MaintainUnit_Should_Remove_Destroyed_Unit_From_List()
         {
             // Arrange
-            int maxUnitToGenerate = 11;
+            int maxUnitToGenerate = 10;
 
             for (int i = 0; i < maxUnitToGenerate; i++)
             {
@@ -147,8 +146,6 @@ namespace Tests
             // Act
             // Destroy units that is even in the index position
             Object.DestroyImmediate(Faction.Units[0].gameObject);
-
-
 
             // Assert
             Assert.DoesNotThrow(() => Faction.MaintainUnit());

--- a/DEFCON Z/Assets/Tests/PlayMode Tests/FactionTest.cs
+++ b/DEFCON Z/Assets/Tests/PlayMode Tests/FactionTest.cs
@@ -104,6 +104,10 @@ namespace Tests
             Assert.That(Faction.Resource.ResourcePoint, Is.EqualTo(expectedEndResource));
         }
 
+        /// <summary>
+        /// This tests that MaintainUnit should remove destroyed/dead unit from
+        /// faction's list.
+        /// </summary>
         [Test]
         public void MaintainUnit_Should_Remove_Destroyed_Unit_From_List()
         {
@@ -134,6 +138,10 @@ namespace Tests
             Assert.That(Faction.Units.Count, Is.EqualTo(maxUnitToGenerate / 2));
         }
 
+        /// <summary>
+        /// This test ensure that MaintainUnit does not throw null when accessing
+        /// 'Unit' object.
+        /// </summary>
         [Test]
         public void MaintainUnit_Should_Not_Throw_Null()
         {


### PR DESCRIPTION
## Description
Dead units will be removed from the Faction and no longer trigger Null Exception.

## Related Issue
Fixes #69 

## Motivation and Context
Null Reference was caught and caused the game to break when a unit has been killed.

## How Has This Been Tested?
Two new tests has been created. One checks that null objects are not accessed and another checks if the unit has been removed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code Refactor (styling fix, extracting methods, etc. Does not cause any functionality changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
