### PR TITLE
Remove Singleton

### DIFF
--- a/DEFCON Z/Assets/Scenes/Levels/DEFCON City/defcon city.unity
+++ b/DEFCON Z/Assets/Scenes/Levels/DEFCON City/defcon city.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -3774,6 +3774,11 @@ PrefabInstance:
       propertyPath: camObject
       value: 
       objectReference: {fileID: 336987419}
+    - target: {fileID: 2236229889046659882, guid: 2501a28f187da884dac09869c1d24e56,
+        type: 3}
+      propertyPath: boost
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8731220371253252657, guid: 2501a28f187da884dac09869c1d24e56,
         type: 3}
       propertyPath: labelSelectedObjectName
@@ -8535,7 +8540,7 @@ GameObject:
   - component: {fileID: 1196489416}
   m_Layer: 0
   m_Name: GameManager
-  m_TagString: Untagged
+  m_TagString: GameManager
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/DEFCON Z/Assets/Scripts/GameManager.cs
+++ b/DEFCON Z/Assets/Scripts/GameManager.cs
@@ -10,8 +10,6 @@ namespace DefconZ
 {
     public class GameManager : MonoBehaviour
     {
-        public static GameManager Instance = null;
-
         /// <summary>
         /// Holds the faction's information of the game.
         /// </summary>
@@ -19,17 +17,11 @@ namespace DefconZ
 
         public IDictionary<Guid, Combat> ActiveCombats;
 
+        private Clock _clock;
+
         private void Awake()
         {
-            if (Instance == null)
-            {
-                Instance = this;
-            }
-            else if (Instance != this)
-            {
-                Destroy(gameObject);
-            }
-
+            _clock = gameObject.AddComponent<Clock>();
             Factions = new List<Faction>();
             ActiveCombats = new ConcurrentDictionary<Guid, Combat>();
         }
@@ -56,10 +48,8 @@ namespace DefconZ
             humanFaction.RecruitUnit();
             zombieFaction.RecruitUnit();
 
-            var clock = Clock.Instance;
-
-            clock.GameCycleElapsed += Clock_GameCycleElapsed;
-            clock.GameCycleElapsed += Combat;
+            _clock.GameCycleElapsed += Clock_GameCycleElapsed;
+            _clock.GameCycleElapsed += Combat;
 
             // Once the GameManager has finished initialising, tell the in-game UI to initialise
             GameObject.Find("InGameUI").GetComponent<InGameUI>().InitUI(humanFaction);
@@ -107,7 +97,7 @@ namespace DefconZ
                 Debug.Log($"{faction.FactionName} has {faction.Resource.ResourcePoint} amount of resources.");
             }
 
-            Debug.Log("Game day elapsed " + Clock.Instance.GameDay);
+            Debug.Log("Game day elapsed " + _clock.GameDay);
         }
 
         /// <summary>

--- a/DEFCON Z/Assets/Scripts/Simulation/Clock.cs
+++ b/DEFCON Z/Assets/Scripts/Simulation/Clock.cs
@@ -9,8 +9,6 @@ using UnityEngine;
 /// </summary>
 public class Clock : MonoBehaviour
 {
-    public static Clock Instance = null;
-
     /// <summary>
     /// Occurs when [a game cycle passes].
     /// </summary>
@@ -54,14 +52,6 @@ public class Clock : MonoBehaviour
     /// </summary>
     private void Awake()
     {
-        if (Instance == null)
-        {
-            Instance = this;
-        }
-        else if (Instance != this)
-        {
-            Destroy(gameObject);
-        }
     }
 
     /// <summary>

--- a/DEFCON Z/Assets/Scripts/UI/PlayerUI.cs
+++ b/DEFCON Z/Assets/Scripts/UI/PlayerUI.cs
@@ -123,9 +123,9 @@ namespace DefconZ.UI
         }
 
         /// <summary>
-		/// Action when purchase unit button is pressed
-		/// </summary>
-		public void PurchaseUnitAction()
+        /// Action when purchase unit button is pressed
+        /// </summary>
+        public void PurchaseUnitAction()
         {
             playerFaction.RecruitUnit();
         }

--- a/DEFCON Z/Assets/Scripts/UI/PlayerUI.cs
+++ b/DEFCON Z/Assets/Scripts/UI/PlayerUI.cs
@@ -1,6 +1,4 @@
 ﻿using DefconZ.Units;
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -22,6 +20,7 @@ namespace DefconZ.UI
         public Color enemyColor;
 
         private Faction playerFaction;
+
         [SerializeField]
         private Player player;
 
@@ -36,7 +35,7 @@ namespace DefconZ.UI
         /// </summary>
         public void GameClockSubscribe()
         {
-            var clock = Clock.Instance;
+            var clock = GameObject.FindGameObjectWithTag(nameof(GameManager)).GetComponent<Clock>();
             clock.GameCycleElapsed += UpdateResourcePoint;
             clock.GameCycleElapsed += UpdateSelectionDisplayEvent;
         }
@@ -55,7 +54,7 @@ namespace DefconZ.UI
         /// Updates the UI Selection area of the UI from the given object
         /// </summary>
         /// <param name="obj"></param>
-        /// 
+        ///
         public void UpdateResourcePoint(object sender, System.EventArgs e)
         {
             if (playerFaction != null)

--- a/DEFCON Z/Assets/Scripts/Units/UnitBase.cs
+++ b/DEFCON Z/Assets/Scripts/Units/UnitBase.cs
@@ -23,6 +23,8 @@ namespace DefconZ
         [SerializeField]
         private AudioSource audioSource;
 
+        private GameManager _gameManager;
+
         /*
          * All unit has an initial base health of 100 and base damage of 10.
          * The most barebone/basic unit takes 10x hit to be defeated.
@@ -35,6 +37,7 @@ namespace DefconZ
         // Start is called before the first frame update
         public void Start()
         {
+            _gameManager = GameObject.FindGameObjectWithTag(nameof(GameManager)).GetComponent<GameManager>();
             navMeshAgent = GetComponent<NavMeshAgent>();
             audioSource = GetComponent<AudioSource>();
 
@@ -126,7 +129,7 @@ namespace DefconZ
                 {
                     if (CurrentCombat != null)
                     {
-                        if (GameManager.Instance.ActiveCombats.Remove(CurrentCombat.CombatId))
+                        if (_gameManager.ActiveCombats.Remove(CurrentCombat.CombatId))
                         {
                             Debug.Log($"Combat with {CurrentCombat.CombatId} removed");
                         }
@@ -175,7 +178,7 @@ namespace DefconZ
                     _targetUnit.CurrentCombat = CurrentCombat;
 
                     // Register the combat to the game manager.
-                    var listOfCombat = GameManager.Instance.ActiveCombats;
+                    var listOfCombat = _gameManager.ActiveCombats;
                     listOfCombat.Add(CurrentCombat.CombatId, CurrentCombat);
 
                     Debug.Log($"Created new Combat with id {CurrentCombat.CombatId}");
@@ -244,9 +247,9 @@ namespace DefconZ
             return CurrentCombat != null;
         }
 
-        private static bool RemoveCombat(Combat combatToRemove)
+        private bool RemoveCombat(Combat combatToRemove)
         {
-            var removeResult = GameManager.Instance.ActiveCombats.Remove(combatToRemove.CombatId);
+            var removeResult = _gameManager.ActiveCombats.Remove(combatToRemove.CombatId);
             combatToRemove.ClearCombat();
 
             return removeResult;

--- a/DEFCON Z/ProjectSettings/TagManager.asset
+++ b/DEFCON Z/ProjectSettings/TagManager.asset
@@ -6,6 +6,7 @@ TagManager:
   tags:
   - GameObject
   - Terrain
+  - GameManager
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
## Description
Remove the use of Singleton for `GameManager` and `Clock`.

## Motivation and Context
This will allow scene to be reloaded with new instance of `GameManager` and `Clock` if the scene is reloaded or loaded a new scene. Without the use of Singleton will make the code more flexible in the future.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code Refactor (styling fix, extracting methods, etc. Does not cause any functionality changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
