### PR TITLE
Capture-able Zones

### DIFF
--- a/DEFCON Z/Assets/Materials/Zone.meta
+++ b/DEFCON Z/Assets/Materials/Zone.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 89ad454ac945eb74f8f4d6cfded5fab3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DEFCON Z/Assets/Materials/Zone/FriendlyZone.mat
+++ b/DEFCON Z/Assets/Materials/Zone/FriendlyZone.mat
@@ -1,0 +1,78 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: FriendlyZone
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: _ALPHABLEND_ON
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 3000
+  stringTagMap:
+    RenderType: Transparent
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 10
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 2
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 5
+    - _UVSec: 0
+    - _ZWrite: 0
+    m_Colors:
+    - _Color: {r: 0.013375282, g: 1, b: 0, a: 0.11764706}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/DEFCON Z/Assets/Materials/Zone/FriendlyZone.mat.meta
+++ b/DEFCON Z/Assets/Materials/Zone/FriendlyZone.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6bfe7a69bbd53804fb2b92fe8c63dacf
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DEFCON Z/Assets/Prefabs/Level/Captureable Zone.prefab
+++ b/DEFCON Z/Assets/Prefabs/Level/Captureable Zone.prefab
@@ -1,0 +1,140 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7334471905579142739
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7334471905579142738}
+  - component: {fileID: 1568097407870418402}
+  - component: {fileID: 1165005109150998190}
+  m_Layer: 0
+  m_Name: Captureable Zone
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7334471905579142738
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7334471905579142739}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7334471906433911890}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1568097407870418402
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7334471905579142739}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b9debe1cbce2a884484b8a90a5f00245, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  zoneManager: {fileID: 0}
+  zoneOwner: {fileID: 0}
+  zoneMaterial: {fileID: 0}
+--- !u!65 &1165005109150998190
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7334471905579142739}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 9.9, y: 5, z: 9.9}
+  m_Center: {x: 0, y: 2.5, z: 0}
+--- !u!1 &7334471906433911891
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7334471906433911890}
+  - component: {fileID: 7334471906433911895}
+  - component: {fileID: 7334471906433911888}
+  m_Layer: 0
+  m_Name: ZoneDisplay
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7334471906433911890
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7334471906433911891}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 2.5, z: 0}
+  m_LocalScale: {x: 9.9, y: 5, z: 9.9}
+  m_Children: []
+  m_Father: {fileID: 7334471905579142738}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &7334471906433911895
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7334471906433911891}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &7334471906433911888
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7334471906433911891}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 6bfe7a69bbd53804fb2b92fe8c63dacf, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0

--- a/DEFCON Z/Assets/Prefabs/Level/Captureable Zone.prefab
+++ b/DEFCON Z/Assets/Prefabs/Level/Captureable Zone.prefab
@@ -47,7 +47,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   zoneManager: {fileID: 0}
   zoneOwner: {fileID: 0}
+  zoneResourceValue: 500
   zoneMaterial: {fileID: 0}
+  unitsInZone: []
 --- !u!65 &1165005109150998190
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/DEFCON Z/Assets/Prefabs/Level/Captureable Zone.prefab.meta
+++ b/DEFCON Z/Assets/Prefabs/Level/Captureable Zone.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7c1b88f58e0eadf4da1212399575f6d9
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DEFCON Z/Assets/Prefabs/Level/ZoneManager.prefab
+++ b/DEFCON Z/Assets/Prefabs/Level/ZoneManager.prefab
@@ -1,0 +1,56 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2674913275903349531
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2674913275903349525}
+  - component: {fileID: 2674913275903349530}
+  m_Layer: 2
+  m_Name: ZoneManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2674913275903349525
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2674913275903349531}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2674913275903349530
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2674913275903349531}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f1bd2702c22bc448a31699732fb7b5c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  zonePrefab: {fileID: 7334471905579142739, guid: 7c1b88f58e0eadf4da1212399575f6d9,
+    type: 3}
+  generateZones: 1
+  worldWidth: 20
+  worldHeight: 20
+  zoneSpacing: 10
+  neutralColor: {r: 0.41509432, g: 0.41509432, b: 0.41509432, a: 0.3529412}
+  friendlyColor: {r: 0.011764706, g: 1, b: 0, a: 0.3529412}
+  enemyColor: {r: 1, g: 0, b: 0.029075146, a: 0.3529412}
+  managedZones: []
+  zoneDisplayActive: 1

--- a/DEFCON Z/Assets/Prefabs/Level/ZoneManager.prefab
+++ b/DEFCON Z/Assets/Prefabs/Level/ZoneManager.prefab
@@ -27,7 +27,8 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 3007551023794624484}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -54,3 +55,48 @@ MonoBehaviour:
   enemyColor: {r: 1, g: 0, b: 0.029075146, a: 0.3529412}
   managedZones: []
   zoneDisplayActive: 1
+--- !u!1 &4059300721628739953
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3007551023794624484}
+  - component: {fileID: 2776352698265356989}
+  m_Layer: 2
+  m_Name: CustomZoneContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3007551023794624484
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4059300721628739953}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2674913275903349525}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2776352698265356989
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4059300721628739953}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a63749ab35abfbe46aadab69a47d4bff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  zoneManager: {fileID: 2674913275903349530}
+  customZones: []

--- a/DEFCON Z/Assets/Prefabs/Level/ZoneManager.prefab.meta
+++ b/DEFCON Z/Assets/Prefabs/Level/ZoneManager.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4f94da3b589d60544a5e72a74e12b1b3
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DEFCON Z/Assets/Scenes/Levels/DEFCON City/defcon city.unity
+++ b/DEFCON Z/Assets/Scenes/Levels/DEFCON City/defcon city.unity
@@ -3775,6 +3775,16 @@ PrefabInstance:
       propertyPath: camObject
       value: 
       objectReference: {fileID: 336987419}
+    - target: {fileID: 2236229889046659882, guid: 2501a28f187da884dac09869c1d24e56,
+        type: 3}
+      propertyPath: minSpeed
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 2236229889046659882, guid: 2501a28f187da884dac09869c1d24e56,
+        type: 3}
+      propertyPath: maxSpeed
+      value: 20
+      objectReference: {fileID: 0}
     - target: {fileID: 8731220371253252657, guid: 2501a28f187da884dac09869c1d24e56,
         type: 3}
       propertyPath: labelSelectedObjectName
@@ -4845,8 +4855,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   zonePrefab: {fileID: 7334471905579142739, guid: 7c1b88f58e0eadf4da1212399575f6d9,
     type: 3}
-  worldWidth: 5
-  worldHeight: 5
+  worldWidth: 20
+  worldHeight: 20
   zoneSpacing: 10
   neutralColor: {r: 0.41509432, g: 0.41509432, b: 0.41509432, a: 0.11764706}
   friendlyColor: {r: 0.011764706, g: 1, b: 0, a: 0.11764706}

--- a/DEFCON Z/Assets/Scenes/Levels/DEFCON City/defcon city.unity
+++ b/DEFCON Z/Assets/Scenes/Levels/DEFCON City/defcon city.unity
@@ -4855,12 +4855,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   zonePrefab: {fileID: 7334471905579142739, guid: 7c1b88f58e0eadf4da1212399575f6d9,
     type: 3}
+  generateZones: 0
   worldWidth: 20
   worldHeight: 20
   zoneSpacing: 10
-  neutralColor: {r: 0.41509432, g: 0.41509432, b: 0.41509432, a: 0.11764706}
-  friendlyColor: {r: 0.011764706, g: 1, b: 0, a: 0.11764706}
-  enemyColor: {r: 1, g: 0, b: 0.029075146, a: 0.11764706}
+  neutralColor: {r: 0.41509432, g: 0.41509432, b: 0.41509432, a: 0.3529412}
+  friendlyColor: {r: 0.011764706, g: 1, b: 0, a: 0.3529412}
+  enemyColor: {r: 1, g: 0, b: 0.029075146, a: 0.3529412}
   managedZones: []
   zoneDisplayActive: 0
 --- !u!4 &694409672

--- a/DEFCON Z/Assets/Scenes/Levels/DEFCON City/defcon city.unity
+++ b/DEFCON Z/Assets/Scenes/Levels/DEFCON City/defcon city.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.4465782, g: 0.49641252, b: 0.5748167, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -96,7 +96,8 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaAO: 1
     m_ShowResolutionOverlay: 1
     m_ExportTrainingData: 0
-  m_LightingDataAsset: {fileID: 0}
+  m_LightingDataAsset: {fileID: 112000000, guid: f36c8329d942ac448a149b790e3d7a7b,
+    type: 2}
   m_UseShadowmask: 1
 --- !u!196 &4
 NavMeshSettings:
@@ -987,6 +988,7 @@ Transform:
   - {fileID: 584486911}
   - {fileID: 1513979558}
   - {fileID: 1123705457}
+  - {fileID: 694409672}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -3783,6 +3785,11 @@ PrefabInstance:
       propertyPath: playerUI
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 784628555139685445, guid: 2501a28f187da884dac09869c1d24e56,
+        type: 3}
+      propertyPath: zoneManager
+      value: 
+      objectReference: {fileID: 694409671}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2501a28f187da884dac09869c1d24e56, type: 3}
 --- !u!1001 &551163212
@@ -4807,6 +4814,59 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2b8815ffbeb42454d83df4020534dca7, type: 3}
+--- !u!1 &694409670
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 694409672}
+  - component: {fileID: 694409671}
+  m_Layer: 2
+  m_Name: ZoneManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &694409671
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 694409670}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f1bd2702c22bc448a31699732fb7b5c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  zonePrefab: {fileID: 7334471905579142739, guid: 7c1b88f58e0eadf4da1212399575f6d9,
+    type: 3}
+  worldWidth: 5
+  worldHeight: 5
+  zoneSpacing: 10
+  neutralColor: {r: 0.41509432, g: 0.41509432, b: 0.41509432, a: 0.11764706}
+  friendlyColor: {r: 0.011764706, g: 1, b: 0, a: 0.11764706}
+  enemyColor: {r: 1, g: 0, b: 0.029075146, a: 0.11764706}
+  managedZones: []
+  zoneDisplayActive: 0
+--- !u!4 &694409672
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 694409670}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 138724530}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &696124711 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5805956175417019269, guid: 89c64b4332d51b94eabe8fb36ac1044e,

--- a/DEFCON Z/Assets/Scenes/Levels/DEFCON City/defcon city.unity
+++ b/DEFCON Z/Assets/Scenes/Levels/DEFCON City/defcon city.unity
@@ -988,7 +988,7 @@ Transform:
   - {fileID: 584486911}
   - {fileID: 1513979558}
   - {fileID: 1123705457}
-  - {fileID: 694409672}
+  - {fileID: 755133321}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -3794,7 +3794,7 @@ PrefabInstance:
         type: 3}
       propertyPath: zoneManager
       value: 
-      objectReference: {fileID: 694409671}
+      objectReference: {fileID: 755133322}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2501a28f187da884dac09869c1d24e56, type: 3}
 --- !u!1001 &551163212
@@ -4819,60 +4819,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2b8815ffbeb42454d83df4020534dca7, type: 3}
---- !u!1 &694409670
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 694409672}
-  - component: {fileID: 694409671}
-  m_Layer: 2
-  m_Name: ZoneManager
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &694409671
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 694409670}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7f1bd2702c22bc448a31699732fb7b5c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  zonePrefab: {fileID: 7334471905579142739, guid: 7c1b88f58e0eadf4da1212399575f6d9,
-    type: 3}
-  generateZones: 0
-  worldWidth: 20
-  worldHeight: 20
-  zoneSpacing: 10
-  neutralColor: {r: 0.41509432, g: 0.41509432, b: 0.41509432, a: 0.3529412}
-  friendlyColor: {r: 0.011764706, g: 1, b: 0, a: 0.3529412}
-  enemyColor: {r: 1, g: 0, b: 0.029075146, a: 0.3529412}
-  managedZones: []
-  zoneDisplayActive: 0
---- !u!4 &694409672
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 694409670}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 138724530}
-  m_RootOrder: 6
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &696124711 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5805956175417019269, guid: 89c64b4332d51b94eabe8fb36ac1044e,
@@ -5272,6 +5218,24 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1066981264}
   m_PrefabAsset: {fileID: 0}
+--- !u!4 &755133321 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2674913275903349525, guid: 4f94da3b589d60544a5e72a74e12b1b3,
+    type: 3}
+  m_PrefabInstance: {fileID: 1650171025}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &755133322 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2674913275903349530, guid: 4f94da3b589d60544a5e72a74e12b1b3,
+    type: 3}
+  m_PrefabInstance: {fileID: 1650171025}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f1bd2702c22bc448a31699732fb7b5c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &757438692
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -12022,6 +11986,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ea96661379946524885f1bf702f94484, type: 3}
+--- !u!4 &1576670533 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3007551023794624484, guid: 4f94da3b589d60544a5e72a74e12b1b3,
+    type: 3}
+  m_PrefabInstance: {fileID: 1650171025}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1578598185 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4699883680798423777, guid: ea96661379946524885f1bf702f94484,
@@ -12442,6 +12412,95 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2b8815ffbeb42454d83df4020534dca7, type: 3}
+--- !u!1001 &1650171025
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 138724530}
+    m_Modifications:
+    - target: {fileID: 2674913275903349531, guid: 4f94da3b589d60544a5e72a74e12b1b3,
+        type: 3}
+      propertyPath: m_Name
+      value: ZoneManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 2674913275903349525, guid: 4f94da3b589d60544a5e72a74e12b1b3,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2674913275903349525, guid: 4f94da3b589d60544a5e72a74e12b1b3,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2674913275903349525, guid: 4f94da3b589d60544a5e72a74e12b1b3,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2674913275903349525, guid: 4f94da3b589d60544a5e72a74e12b1b3,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2674913275903349525, guid: 4f94da3b589d60544a5e72a74e12b1b3,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2674913275903349525, guid: 4f94da3b589d60544a5e72a74e12b1b3,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2674913275903349525, guid: 4f94da3b589d60544a5e72a74e12b1b3,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2674913275903349525, guid: 4f94da3b589d60544a5e72a74e12b1b3,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2674913275903349525, guid: 4f94da3b589d60544a5e72a74e12b1b3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2674913275903349525, guid: 4f94da3b589d60544a5e72a74e12b1b3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2674913275903349525, guid: 4f94da3b589d60544a5e72a74e12b1b3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2674913275903349530, guid: 4f94da3b589d60544a5e72a74e12b1b3,
+        type: 3}
+      propertyPath: generateZones
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2776352698265356989, guid: 4f94da3b589d60544a5e72a74e12b1b3,
+        type: 3}
+      propertyPath: customZones.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2776352698265356989, guid: 4f94da3b589d60544a5e72a74e12b1b3,
+        type: 3}
+      propertyPath: zoneManager
+      value: 
+      objectReference: {fileID: 755133322}
+    - target: {fileID: 2776352698265356989, guid: 4f94da3b589d60544a5e72a74e12b1b3,
+        type: 3}
+      propertyPath: customZones.Array.data[0]
+      value: 
+      objectReference: {fileID: 1928256485}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4f94da3b589d60544a5e72a74e12b1b3, type: 3}
 --- !u!4 &1651614922 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 7829775905965705260, guid: 1bfbdd8b7d30ebe47b1f5fc77485b24e,
@@ -13861,6 +13920,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1604345938}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1928256485 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1568097407870418402, guid: 7c1b88f58e0eadf4da1212399575f6d9,
+    type: 3}
+  m_PrefabInstance: {fileID: 1996496263}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b9debe1cbce2a884484b8a90a5f00245, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1929081237
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -14334,6 +14405,75 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ea96661379946524885f1bf702f94484, type: 3}
+--- !u!1001 &1996496263
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1576670533}
+    m_Modifications:
+    - target: {fileID: 7334471905579142739, guid: 7c1b88f58e0eadf4da1212399575f6d9,
+        type: 3}
+      propertyPath: m_Name
+      value: Captureable Zone
+      objectReference: {fileID: 0}
+    - target: {fileID: 7334471905579142738, guid: 7c1b88f58e0eadf4da1212399575f6d9,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7334471905579142738, guid: 7c1b88f58e0eadf4da1212399575f6d9,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7334471905579142738, guid: 7c1b88f58e0eadf4da1212399575f6d9,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -24.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7334471905579142738, guid: 7c1b88f58e0eadf4da1212399575f6d9,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7334471905579142738, guid: 7c1b88f58e0eadf4da1212399575f6d9,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7334471905579142738, guid: 7c1b88f58e0eadf4da1212399575f6d9,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7334471905579142738, guid: 7c1b88f58e0eadf4da1212399575f6d9,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7334471905579142738, guid: 7c1b88f58e0eadf4da1212399575f6d9,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7334471905579142738, guid: 7c1b88f58e0eadf4da1212399575f6d9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7334471905579142738, guid: 7c1b88f58e0eadf4da1212399575f6d9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7334471905579142738, guid: 7c1b88f58e0eadf4da1212399575f6d9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7c1b88f58e0eadf4da1212399575f6d9, type: 3}
 --- !u!1001 &1999735009
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/DEFCON Z/Assets/Scripts/GameLevel/CustomZoneContainer.cs
+++ b/DEFCON Z/Assets/Scripts/GameLevel/CustomZoneContainer.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace DefconZ.GameLevel
+{
+    public class CustomZoneContainer : MonoBehaviour
+    {
+        public ZoneManager zoneManager;
+
+        public List<Zone> customZones;
+        // Start is called before the first frame update
+        void Start()
+        {
+            if (zoneManager != null)
+            {
+                // check that the managed zones list is initialised
+                if (zoneManager.managedZones != null)
+                {
+                    AddZonesToManager();
+                }
+                else
+                {
+                    Debug.LogError(zoneManager.name + " does not have an initialised managedZones list");
+                }
+            }
+            else
+            {
+                Debug.LogError("Zone Manager not configured for: " + name);
+            }
+        }
+
+        /// <summary>
+        /// Adds the zones stored by the custom zone container to the manager
+        /// </summary>
+        private void AddZonesToManager()
+        {
+            foreach (Zone _zone in customZones)
+            {
+                _zone.Init(zoneManager, null);
+                zoneManager.managedZones.Add(_zone);
+            }
+        }
+    }
+}

--- a/DEFCON Z/Assets/Scripts/GameLevel/CustomZoneContainer.cs.meta
+++ b/DEFCON Z/Assets/Scripts/GameLevel/CustomZoneContainer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a63749ab35abfbe46aadab69a47d4bff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DEFCON Z/Assets/Scripts/GameLevel/Zone.cs
+++ b/DEFCON Z/Assets/Scripts/GameLevel/Zone.cs
@@ -134,14 +134,20 @@ namespace DefconZ.GameLevel
                 // Check if the current zone is owned
                 if (zoneOwner != null)
                 {
+                    //Debug.LogError(faction + " " + zoneOwner);
                     // Remove the resource cap boost for the owner of the zone
                     zoneOwner.Resource.MaxResourcePoint -= zoneResourceValue;
                 }
 
                 // Assign the new zone owner
                 zoneOwner = faction;
-                // Add the resource cap boost to the new owner
-                zoneOwner.Resource.MaxResourcePoint += zoneResourceValue;
+
+                // Check if a new faction owner is present
+                if (zoneOwner != null)
+                {
+                    // Add the resource cap boost to the new owner
+                    zoneOwner.Resource.MaxResourcePoint += zoneResourceValue;
+                }
 
                 // Update the display color of the zone
                 if (faction == null)

--- a/DEFCON Z/Assets/Scripts/GameLevel/Zone.cs
+++ b/DEFCON Z/Assets/Scripts/GameLevel/Zone.cs
@@ -1,0 +1,113 @@
+﻿using DefconZ.Units;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace DefconZ.GameLevel
+{
+    public class Zone : MonoBehaviour
+    {
+        public ZoneManager zoneManager;
+        public Faction zoneOwner;
+
+        [SerializeField]
+        private Material zoneMaterial;
+
+        [SerializeField]
+        private List<UnitBase> unitsInZone;
+
+        private void Awake()
+        {
+            unitsInZone = new List<UnitBase>();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="zoneManager"></param>
+        /// <param name="faction"></param>
+        public void Init(ZoneManager zoneManager, Faction faction)
+        {
+            this.zoneManager = zoneManager;
+            zoneMaterial = gameObject.transform.GetComponentInChildren<MeshRenderer>().material;
+
+            SetZoneOwner(faction);
+
+            gameObject.layer = 2; // Sets the gameobject layer to ignore raycasts
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        private void UpdateZone()
+        {
+
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="other"></param>
+        private void OnTriggerEnter(Collider other)
+        {
+            UnitBase _unit = other.GetComponent<UnitBase>();
+            if (_unit != null)
+            {
+                Debug.LogError(_unit.objName + " entered zone");
+                SetZoneOwner(_unit.FactionOwner);
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="other"></param>
+        private void OnTriggerExit(Collider other)
+        {
+            UnitBase _unit = other.GetComponent<UnitBase>();
+            if (_unit != null)
+            {
+                Debug.LogError(_unit.objName + " exited zone");
+            }
+        }
+
+        protected Faction GetZoneOwner()
+        {
+            return zoneOwner;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="faction"></param>
+        public void SetZoneOwner(Faction faction)
+        {
+            zoneOwner = faction;
+            if (faction == null)
+            {
+                zoneMaterial.color = zoneManager.neutralColor;
+            }
+            else if (faction.IsPlayerUnit)
+            {
+                zoneMaterial.color = zoneManager.friendlyColor;
+            }
+            else
+            {
+                zoneMaterial.color = zoneManager.enemyColor;
+            }
+        }
+
+        public bool IsInsideZone(UnitBase unit)
+        {
+            return unitsInZone.Contains(unit);
+        }
+
+        public void RemoveFromZone(UnitBase unit)
+        {
+            if (unitsInZone.Contains(unit))
+            {
+                unitsInZone.Remove(unit);
+            }
+        }
+    }
+}

--- a/DEFCON Z/Assets/Scripts/GameLevel/Zone.cs
+++ b/DEFCON Z/Assets/Scripts/GameLevel/Zone.cs
@@ -9,6 +9,7 @@ namespace DefconZ.GameLevel
     {
         public ZoneManager zoneManager;
         public Faction zoneOwner;
+        public float zoneResourceValue;
 
         [SerializeField]
         private Material zoneMaterial;
@@ -30,7 +31,7 @@ namespace DefconZ.GameLevel
         {
             this.zoneManager = zoneManager;
             zoneMaterial = gameObject.transform.GetComponentInChildren<MeshRenderer>().material;
-
+            zoneMaterial.color = zoneManager.neutralColor;
             SetZoneOwner(faction);
 
             gameObject.layer = 2; // Sets the gameobject layer to ignore raycasts
@@ -81,6 +82,7 @@ namespace DefconZ.GameLevel
                 else
                 {
                     SetZoneOwner(_owner);
+
                 }
             }
         }
@@ -127,18 +129,34 @@ namespace DefconZ.GameLevel
         /// <param name="faction"></param>
         public void SetZoneOwner(Faction faction)
         {
-            zoneOwner = faction;
-            if (faction == null)
+            // Check that the current owner is not the same as the new owner
+            if (zoneOwner != faction)
             {
-                zoneMaterial.color = zoneManager.neutralColor;
-            }
-            else if (faction.IsPlayerUnit)
-            {
-                zoneMaterial.color = zoneManager.friendlyColor;
-            }
-            else
-            {
-                zoneMaterial.color = zoneManager.enemyColor;
+                // Check if the current zone is owned
+                if (zoneOwner != null)
+                {
+                    // Remove the resource cap boost for the owner of the zone
+                    zoneOwner.Resource.MaxResourcePoint -= zoneResourceValue;
+                }
+
+                // Assign the new zone owner
+                zoneOwner = faction;
+                // Add the resource cap boost to the new owner
+                zoneOwner.Resource.MaxResourcePoint += zoneResourceValue;
+
+                // Update the display color of the zone
+                if (faction == null)
+                {
+                    zoneMaterial.color = zoneManager.neutralColor;
+                }
+                else if (faction.IsPlayerUnit)
+                {
+                    zoneMaterial.color = zoneManager.friendlyColor;
+                }
+                else
+                {
+                    zoneMaterial.color = zoneManager.enemyColor;
+                }
             }
         }
 
@@ -163,6 +181,7 @@ namespace DefconZ.GameLevel
                 unitsInZone.Remove(unit);
             }
 
+            // Call an update to the zone
             UpdateZone();
         }
     }

--- a/DEFCON Z/Assets/Scripts/GameLevel/Zone.cs
+++ b/DEFCON Z/Assets/Scripts/GameLevel/Zone.cs
@@ -39,74 +39,67 @@ namespace DefconZ.GameLevel
 
         /// <summary>
         /// Updates the current zone
-        /// Itterates through units inside zone and calculates the correct owner of the zone
+        /// Iterates through units inside zone and calculates the correct owner of the zone
         /// </summary>
         private void UpdateZone()
         {
-            Faction _owner = null;
-            bool _multipleFactions = false;
-            int _unitCount = 0;
+            Faction owner = null;
+            bool multipleFactions = false;
             
             // Calculate the current owner of the zone
-            foreach (UnitBase _unit in unitsInZone)
+            foreach (UnitBase unit in unitsInZone)
             {
-                if (_owner == null)
+                if (owner == null)
                 {
-                    _owner = _unit.FactionOwner;
+                    owner = unit.FactionOwner;
                 }
                 else
                 {
                     // Check if the current calculated owner is different to the unit
-                    if (_unit.FactionOwner != _owner)
+                    if (unit.FactionOwner != owner)
                     {
-                        _multipleFactions = true;
-                    }
-                    else if (_owner == null)
-                    {
-                        _owner = _unit.FactionOwner;
+                        multipleFactions = true;
                     }
                 }
-
-                _unitCount++;
             }
 
             // Set the zones owner
             // If no units are in the zone, do not change the owner
-            if (_unitCount > 0)
+            if (unitsInZone.Count > 0)
             {
                 // If multiple factions are present, there is no owner of the zone
-                if (_multipleFactions)
+                if (multipleFactions)
                 {
                     SetZoneOwner(null);
                 }
                 else
                 {
-                    SetZoneOwner(_owner);
+                    SetZoneOwner(owner);
                 }
             }
         }
 
         private void OnTriggerEnter(Collider other)
         {
-            UnitBase _unit = other.GetComponent<UnitBase>();
-            if (_unit != null)
+            UnitBase unit = other.GetComponent<UnitBase>();
+            if (unit != null)
             {
-                Debug.Log(_unit.objName + " entered zone");
-                unitsInZone.Add(_unit);
-                _unit.currentZone = this;
+                Debug.Log(unit.objName + " entered zone");
+                unitsInZone.Add(unit);
+                unit.currentZone = this;
                 UpdateZone();
             }
         }
 
         private void OnTriggerExit(Collider other)
         {
-            UnitBase _unit = other.GetComponent<UnitBase>();
-            if (_unit != null)
+            UnitBase unit = other.GetComponent<UnitBase>();
+            if (unit != null)
             {
-                Debug.Log(_unit.objName + " exited zone");
+                Debug.Log(unit.objName + " exited zone");
 
                 // Remove the unit from the zone
-                RemoveFromZone(_unit);
+                RemoveFromZone(unit);
 
                 UpdateZone();
             }
@@ -149,18 +142,27 @@ namespace DefconZ.GameLevel
                 }
 
                 // Update the display color of the zone
-                if (faction == null)
-                {
-                    zoneMaterial.color = zoneManager.neutralColor;
-                }
-                else if (faction.IsPlayerUnit)
-                {
-                    zoneMaterial.color = zoneManager.friendlyColor;
-                }
-                else
-                {
-                    zoneMaterial.color = zoneManager.enemyColor;
-                }
+                UpdateZoneColor(zoneOwner);
+            }
+        }
+
+        /// <summary>
+        /// Updates the display color for the zone
+        /// </summary>
+        /// <param name="faction"></param>
+        private void UpdateZoneColor(Faction faction)
+        {
+            if (faction == null)
+            {
+                zoneMaterial.color = zoneManager.neutralColor;
+            }
+            else if (faction.IsPlayerUnit)
+            {
+                zoneMaterial.color = zoneManager.friendlyColor;
+            }
+            else
+            {
+                zoneMaterial.color = zoneManager.enemyColor;
             }
         }
 

--- a/DEFCON Z/Assets/Scripts/GameLevel/Zone.cs
+++ b/DEFCON Z/Assets/Scripts/GameLevel/Zone.cs
@@ -22,7 +22,7 @@ namespace DefconZ.GameLevel
         }
 
         /// <summary>
-        /// 
+        /// Initialises the zone
         /// </summary>
         /// <param name="zoneManager"></param>
         /// <param name="faction"></param>
@@ -37,12 +37,14 @@ namespace DefconZ.GameLevel
         }
 
         /// <summary>
-        /// 
+        /// Updates the current zone
+        /// Itterates through units inside zone and calculates the correct owner of the zone
         /// </summary>
         private void UpdateZone()
         {
             Faction _owner = null;
             bool _multipleFactions = false;
+            int _unitCount = 0;
             
             // Calculate the current owner of the zone
             foreach (UnitBase _unit in unitsInZone)
@@ -63,47 +65,44 @@ namespace DefconZ.GameLevel
                         _owner = _unit.FactionOwner;
                     }
                 }
+
+                _unitCount++;
             }
 
             // Set the zones owner
-            // If multiple factions are present, there is no owner of the zone
-            if (_multipleFactions)
+            // If no units are in the zone, do not change the owner
+            if (_unitCount > 0)
             {
-                SetZoneOwner(null);
+                // If multiple factions are present, there is no owner of the zone
+                if (_multipleFactions)
+                {
+                    SetZoneOwner(null);
+                }
+                else
+                {
+                    SetZoneOwner(_owner);
+                }
             }
-            else
-            {
-                SetZoneOwner(_owner);
-            }
-
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="other"></param>
         private void OnTriggerEnter(Collider other)
         {
             UnitBase _unit = other.GetComponent<UnitBase>();
             if (_unit != null)
             {
-                Debug.LogError(_unit.objName + " entered zone");
+                Debug.Log(_unit.objName + " entered zone");
                 unitsInZone.Add(_unit);
                 _unit.currentZone = this;
                 UpdateZone();
             }
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="other"></param>
         private void OnTriggerExit(Collider other)
         {
             UnitBase _unit = other.GetComponent<UnitBase>();
             if (_unit != null)
             {
-                Debug.LogError(_unit.objName + " exited zone");
+                Debug.Log(_unit.objName + " exited zone");
 
                 // Remove the unit from the zone
                 RemoveFromZone(_unit);
@@ -113,7 +112,7 @@ namespace DefconZ.GameLevel
         }
 
         /// <summary>
-        /// 
+        /// Returns the faction that controls the zone
         /// </summary>
         /// <returns></returns>
         protected Faction GetZoneOwner()
@@ -122,7 +121,8 @@ namespace DefconZ.GameLevel
         }
 
         /// <summary>
-        /// 
+        /// Sets the owner of the zone.
+        /// Updates the visual display of the zone.
         /// </summary>
         /// <param name="faction"></param>
         public void SetZoneOwner(Faction faction)
@@ -143,17 +143,17 @@ namespace DefconZ.GameLevel
         }
 
         /// <summary>
-        /// 
+        /// Checks if the given unit is inside the zone
         /// </summary>
         /// <param name="unit"></param>
-        /// <returns></returns>
+        /// <returns>True if the given unit is inside the zone</returns>
         public bool IsInsideZone(UnitBase unit)
         {
             return unitsInZone.Contains(unit);
         }
 
         /// <summary>
-        /// 
+        /// Removes the given unit from the zone list
         /// </summary>
         /// <param name="unit"></param>
         public void RemoveFromZone(UnitBase unit)

--- a/DEFCON Z/Assets/Scripts/GameLevel/Zone.cs
+++ b/DEFCON Z/Assets/Scripts/GameLevel/Zone.cs
@@ -134,7 +134,6 @@ namespace DefconZ.GameLevel
                 // Check if the current zone is owned
                 if (zoneOwner != null)
                 {
-                    //Debug.LogError(faction + " " + zoneOwner);
                     // Remove the resource cap boost for the owner of the zone
                     zoneOwner.Resource.MaxResourcePoint -= zoneResourceValue;
                 }

--- a/DEFCON Z/Assets/Scripts/GameLevel/Zone.cs
+++ b/DEFCON Z/Assets/Scripts/GameLevel/Zone.cs
@@ -82,7 +82,6 @@ namespace DefconZ.GameLevel
                 else
                 {
                     SetZoneOwner(_owner);
-
                 }
             }
         }

--- a/DEFCON Z/Assets/Scripts/GameLevel/Zone.cs
+++ b/DEFCON Z/Assets/Scripts/GameLevel/Zone.cs
@@ -41,6 +41,40 @@ namespace DefconZ.GameLevel
         /// </summary>
         private void UpdateZone()
         {
+            Faction _owner = null;
+            bool _multipleFactions = false;
+            
+            // Calculate the current owner of the zone
+            foreach (UnitBase _unit in unitsInZone)
+            {
+                if (_owner == null)
+                {
+                    _owner = _unit.FactionOwner;
+                }
+                else
+                {
+                    // Check if the current calculated owner is different to the unit
+                    if (_unit.FactionOwner != _owner)
+                    {
+                        _multipleFactions = true;
+                    }
+                    else if (_owner == null)
+                    {
+                        _owner = _unit.FactionOwner;
+                    }
+                }
+            }
+
+            // Set the zones owner
+            // If multiple factions are present, there is no owner of the zone
+            if (_multipleFactions)
+            {
+                SetZoneOwner(null);
+            }
+            else
+            {
+                SetZoneOwner(_owner);
+            }
 
         }
 
@@ -54,7 +88,9 @@ namespace DefconZ.GameLevel
             if (_unit != null)
             {
                 Debug.LogError(_unit.objName + " entered zone");
-                SetZoneOwner(_unit.FactionOwner);
+                unitsInZone.Add(_unit);
+                _unit.currentZone = this;
+                UpdateZone();
             }
         }
 
@@ -68,9 +104,18 @@ namespace DefconZ.GameLevel
             if (_unit != null)
             {
                 Debug.LogError(_unit.objName + " exited zone");
+
+                // Remove the unit from the zone
+                RemoveFromZone(_unit);
+
+                UpdateZone();
             }
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
         protected Faction GetZoneOwner()
         {
             return zoneOwner;
@@ -97,17 +142,28 @@ namespace DefconZ.GameLevel
             }
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="unit"></param>
+        /// <returns></returns>
         public bool IsInsideZone(UnitBase unit)
         {
             return unitsInZone.Contains(unit);
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="unit"></param>
         public void RemoveFromZone(UnitBase unit)
         {
             if (unitsInZone.Contains(unit))
             {
                 unitsInZone.Remove(unit);
             }
+
+            UpdateZone();
         }
     }
 }

--- a/DEFCON Z/Assets/Scripts/GameLevel/Zone.cs.meta
+++ b/DEFCON Z/Assets/Scripts/GameLevel/Zone.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b9debe1cbce2a884484b8a90a5f00245
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DEFCON Z/Assets/Scripts/GameLevel/ZoneManager.cs
+++ b/DEFCON Z/Assets/Scripts/GameLevel/ZoneManager.cs
@@ -40,21 +40,21 @@ namespace DefconZ.GameLevel
         /// </summary>
         private void GenerateLevelZones()
         {
-            ZoneManager _zoneManager = this;
+            ZoneManager zoneManager = this;
             // generate rows
             for (int i = 0; i < worldWidth; i++)
             {
                 // generate columns
                 for (int j = 0; j < worldHeight; j++)
                 {
-                    float _xPos = zoneSpacing * i;
-                    float _zPos = zoneSpacing * j;
+                    float xPos = zoneSpacing * i;
+                    float zPos = zoneSpacing * j;
 
-                    GameObject _zoneObject = Instantiate(zonePrefab, new Vector3(_xPos, 0, _zPos), Quaternion.identity); // Create the zone
-                    Zone _zone = _zoneObject.GetComponent<Zone>();
-                    _zone.Init(_zoneManager, null); // Initialise the zone
-                    _zone.transform.parent = gameObject.transform; // Set the zones parent to be the zone manager, this stops the game heierachy being clogged
-                    managedZones.Add(_zone); // Add the generated zone to the managed zones list
+                    GameObject zoneObject = Instantiate(zonePrefab, new Vector3(xPos, 0, zPos), Quaternion.identity); // Create the zone
+                    Zone zone = zoneObject.GetComponent<Zone>();
+                    zone.Init(zoneManager, null); // Initialise the zone
+                    zone.transform.parent = gameObject.transform; // Set the zones parent to be the zone manager, this stops the game heierachy being clogged
+                    managedZones.Add(zone); // Add the generated zone to the managed zones list
                 }
             }
         }
@@ -67,9 +67,9 @@ namespace DefconZ.GameLevel
         {
             zoneDisplayActive = (zoneDisplayActive) ? false : true;
 
-            foreach (Zone _zone in managedZones)
+            foreach (Zone zone in managedZones)
             {
-                _zone.GetComponentInChildren<MeshRenderer>().enabled = zoneDisplayActive;
+                zone.GetComponentInChildren<MeshRenderer>().enabled = zoneDisplayActive;
             }
         }
     }

--- a/DEFCON Z/Assets/Scripts/GameLevel/ZoneManager.cs
+++ b/DEFCON Z/Assets/Scripts/GameLevel/ZoneManager.cs
@@ -14,8 +14,8 @@ namespace DefconZ.GameLevel
         public float zoneSpacing;
         public Color neutralColor, friendlyColor, enemyColor;
 
-        [SerializeField]
-        private List<Zone> managedZones;
+        public List<Zone> managedZones;
+
         [SerializeField]
         private bool zoneDisplayActive;
 

--- a/DEFCON Z/Assets/Scripts/GameLevel/ZoneManager.cs
+++ b/DEFCON Z/Assets/Scripts/GameLevel/ZoneManager.cs
@@ -7,6 +7,7 @@ namespace DefconZ.GameLevel
     public class ZoneManager : MonoBehaviour
     {
         public GameObject zonePrefab;
+        public bool generateZones;
 
         public int worldWidth;
         public int worldHeight;
@@ -27,7 +28,11 @@ namespace DefconZ.GameLevel
         // Start is called before the first frame update
         void Start()
         {
-            GenerateLevelZones();
+            // Generate zones if the manager is flagged to
+            if (generateZones)
+            {
+                GenerateLevelZones();
+            }
         }
 
         /// <summary>

--- a/DEFCON Z/Assets/Scripts/GameLevel/ZoneManager.cs
+++ b/DEFCON Z/Assets/Scripts/GameLevel/ZoneManager.cs
@@ -1,0 +1,64 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace DefconZ.GameLevel
+{
+    public class ZoneManager : MonoBehaviour
+    {
+        public GameObject zonePrefab;
+
+        public int worldWidth;
+        public int worldHeight;
+        public float zoneSpacing;
+        public Color neutralColor, friendlyColor, enemyColor;
+
+        [SerializeField]
+        private List<Zone> managedZones;
+        [SerializeField]
+        private bool zoneDisplayActive;
+
+        private void Awake()
+        {
+            managedZones = new List<Zone>();
+            zoneDisplayActive = true;
+        }
+
+        // Start is called before the first frame update
+        void Start()
+        {
+            GenerateLevelZones();
+        }
+
+        private void GenerateLevelZones()
+        {
+            ZoneManager _zoneManager = this;
+            // generate rows
+            for (int i = 0; i < worldWidth; i++)
+            {
+                // generate columns
+                for (int j = 0; j < worldHeight; j++)
+                {
+                    float _xPos = zoneSpacing * i;
+                    float _zPos = zoneSpacing * j;
+
+                    GameObject _zoneObject = Instantiate(zonePrefab, new Vector3(_xPos, 0, _zPos), Quaternion.identity); // Create the zone
+                    Zone _zone = _zoneObject.GetComponent<Zone>();
+                    _zone.Init(_zoneManager, null); // Initialise the zone
+                    _zone.transform.parent = gameObject.transform; // Set the zones parent to be the zone manager, this stops the game heierachy being clogged
+                    managedZones.Add(_zone); // Add the generated zone to the managed zones list
+                }
+            }
+        }
+
+        public void ToggleZoneDisplay ()
+        {
+            zoneDisplayActive = (zoneDisplayActive) ? false : true;
+
+            foreach (Zone _zone in managedZones)
+            {
+                _zone.GetComponentInChildren<MeshRenderer>().enabled = zoneDisplayActive;
+            }
+        }
+    }
+}

--- a/DEFCON Z/Assets/Scripts/GameLevel/ZoneManager.cs
+++ b/DEFCON Z/Assets/Scripts/GameLevel/ZoneManager.cs
@@ -30,6 +30,9 @@ namespace DefconZ.GameLevel
             GenerateLevelZones();
         }
 
+        /// <summary>
+        /// Generates the managed zones for the zone manager
+        /// </summary>
         private void GenerateLevelZones()
         {
             ZoneManager _zoneManager = this;
@@ -51,6 +54,10 @@ namespace DefconZ.GameLevel
             }
         }
 
+        /// <summary>
+        /// Toggles the display of the zones to the player
+        /// Does not effect simulation
+        /// </summary>
         public void ToggleZoneDisplay ()
         {
             zoneDisplayActive = (zoneDisplayActive) ? false : true;

--- a/DEFCON Z/Assets/Scripts/GameLevel/ZoneManager.cs.meta
+++ b/DEFCON Z/Assets/Scripts/GameLevel/ZoneManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7f1bd2702c22bc448a31699732fb7b5c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DEFCON Z/Assets/Scripts/Player/InputController.cs
+++ b/DEFCON Z/Assets/Scripts/Player/InputController.cs
@@ -1,10 +1,12 @@
-﻿using UnityEngine;
+﻿using DefconZ.GameLevel;
+using UnityEngine;
 
 namespace DefconZ
 {
     public class InputController : MonoBehaviour
     {
         private Player player;
+        public ZoneManager zoneManager;
 
         // Start is called before the first frame update
         private void Start()
@@ -12,7 +14,7 @@ namespace DefconZ
             player = gameObject.GetComponent<Player>();
         }
 
-        private void FixedUpdate()
+        private void Update()
         {
             // Fire 1 (Left click)
             if (Input.GetButtonDown("Fire1"))
@@ -37,6 +39,12 @@ namespace DefconZ
             else if (Input.GetKeyUp(KeyCode.LeftShift))
             {
                 player.camController.boost = false;
+            }
+
+            // zone display
+            if (Input.GetButtonDown("ZoneDisplay"))
+            {
+                zoneManager.ToggleZoneDisplay();
             }
         }
     }

--- a/DEFCON Z/Assets/Scripts/UI/PlayerUI.cs
+++ b/DEFCON Z/Assets/Scripts/UI/PlayerUI.cs
@@ -59,7 +59,7 @@ namespace DefconZ.UI
         {
             if (playerFaction != null)
             {
-                pointStatus.UpdateSlider(playerFaction.Resource.ResourcePoint);
+                pointStatus.UpdateSlider(playerFaction.Resource.ResourcePoint, playerFaction.Resource.MaxResourcePoint);
             }
         }
 

--- a/DEFCON Z/Assets/Scripts/UI/SliderBar.cs
+++ b/DEFCON Z/Assets/Scripts/UI/SliderBar.cs
@@ -33,8 +33,11 @@ namespace DefconZ.UI
         /// Updates The Slider Bar
         /// </summary>
         /// <param name="currentValue"></param>
-        public void UpdateSlider(float currentValue)
+        public void UpdateSlider(float currentValue, float valueMax)
         {
+            // update the stored values
+            this.valueMax = valueMax;
+
             // Update the label text
             sliderLabel.text = currentValue.ToString("n0") + "/" + valueMax.ToString("n0");
 

--- a/DEFCON Z/Assets/Scripts/Units/UnitBase.cs
+++ b/DEFCON Z/Assets/Scripts/Units/UnitBase.cs
@@ -1,4 +1,5 @@
-﻿using DefconZ.Simulation;
+﻿using DefconZ.GameLevel;
+using DefconZ.Simulation;
 using DefconZ.Units;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,6 +12,7 @@ namespace DefconZ
     {
         public float health = 100;
         public Faction FactionOwner { get; set; }
+        public Zone currentZone;
         public Combat CurrentCombat;
         private Vector3 targetPosition;
         public AudioClip deathSound;
@@ -188,6 +190,10 @@ namespace DefconZ
         /// </summary>
         public virtual void DestroySelf()
         {
+            // Ask the unit to remove itself the current zone
+            currentZone.RemoveFromZone(this);
+
+
             Debug.Log(this.objName + " has reached 0 or less health and has been destroyed");
             audioSource.clip = deathSound; // set the audio source clip to the death sound clip
             audioSource.Play();

--- a/DEFCON Z/Assets/Scripts/Units/UnitBase.cs
+++ b/DEFCON Z/Assets/Scripts/Units/UnitBase.cs
@@ -196,7 +196,6 @@ namespace DefconZ
             // Ask the unit to remove itself the current zone
             currentZone.RemoveFromZone(this);
 
-
             Debug.Log(this.objName + " has reached 0 or less health and has been destroyed");
             audioSource.clip = deathSound; // set the audio source clip to the death sound clip
             audioSource.Play();

--- a/DEFCON Z/ProjectSettings/InputManager.asset
+++ b/DEFCON Z/ProjectSettings/InputManager.asset
@@ -325,3 +325,19 @@ InputManager:
     type: 0
     axis: 0
     joyNum: 0
+  - serializedVersion: 3
+    m_Name: ZoneDisplay
+    descriptiveName: Toggle Zone Display
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: z
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 1000
+    dead: 0.001
+    sensitivity: 1000
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 0
+    joyNum: 0


### PR DESCRIPTION
## Description
Implements capture-able zones to the game level.
Zones captured by a faction provide addition resource income.
A zone is captured by a faction once only units for a single faction exist inside the zone.
The display of zones can be toggled via the "ZoneDisplay" key (default: Z).

## Related Issue
Closes #78 

## Motivation and Context
As a player, I should be able to capture zones from the enemy, to provide more resources to my faction.

## How Has This Been Tested?
All existing tests pass.
Game functions as expected with the addition changes.

## Screenshots (when applicable):
![image](https://user-images.githubusercontent.com/5093393/57894734-0ecc1d80-789c-11e9-8b2b-81ee282f7e2a.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code Refactor (styling fix, extracting methods, etc. Does not cause any functionality changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
