### PR TITLE
Dead Units Fix

### DIFF
--- a/DEFCON Z/Assets/Prefabs/Units/Human.prefab
+++ b/DEFCON Z/Assets/Prefabs/Units/Human.prefab
@@ -1,5 +1,37 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &531767567927275952
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3354885578199409220}
+  m_Layer: 0
+  m_Name: UnitModel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3354885578199409220
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 531767567927275952}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 8306123122223643386}
+  - {fileID: 4711509422384647418}
+  m_Father: {fileID: 6112589138305832836}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6112589138305832958
 GameObject:
   m_ObjectHideFlags: 0
@@ -32,8 +64,7 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 4711509422384647418}
-  - {fileID: 8306123122223643386}
+  - {fileID: 3354885578199409220}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -51,9 +82,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   objName: Survivor
   health: 100
+  currentZone: {fileID: 0}
   deathSound: {fileID: 8300000, guid: beca4447c7e7c5e4f994c4c88a5e04f9, type: 3}
   RecruitCost: 500
   Upkeep: 0.5
+  unitModel: {fileID: 531767567927275952}
   navMeshAgent: {fileID: 0}
   audioSource: {fileID: 0}
 --- !u!136 &6112589138305832952
@@ -209,7 +242,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 6112589138305832836}
+    m_TransformParent: {fileID: 3354885578199409220}
     m_Modifications:
     - target: {fileID: 100002, guid: c7771717923692440bddfd35b073f60e, type: 3}
       propertyPath: m_Name
@@ -229,23 +262,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 400002, guid: c7771717923692440bddfd35b073f60e, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.24166782
+      value: 0.24166784
       objectReference: {fileID: 0}
     - target: {fileID: 400002, guid: c7771717923692440bddfd35b073f60e, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 400002, guid: c7771717923692440bddfd35b073f60e, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 400002, guid: c7771717923692440bddfd35b073f60e, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.970359
+      value: 0.9703591
       objectReference: {fileID: 0}
     - target: {fileID: 400002, guid: c7771717923692440bddfd35b073f60e, type: 3}
       propertyPath: m_RootOrder
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 400002, guid: c7771717923692440bddfd35b073f60e, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -272,7 +305,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 6112589138305832836}
+    m_TransformParent: {fileID: 3354885578199409220}
     m_Modifications:
     - target: {fileID: 100002, guid: 51687450f95b6d34e83af27dd2902f62, type: 3}
       propertyPath: m_Name
@@ -280,7 +313,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 400002, guid: 51687450f95b6d34e83af27dd2902f62, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 400002, guid: 51687450f95b6d34e83af27dd2902f62, type: 3}
       propertyPath: m_LocalPosition.y
@@ -292,7 +325,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 400002, guid: 51687450f95b6d34e83af27dd2902f62, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 400002, guid: 51687450f95b6d34e83af27dd2902f62, type: 3}
       propertyPath: m_LocalRotation.y
@@ -308,7 +341,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 400002, guid: 51687450f95b6d34e83af27dd2902f62, type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 400002, guid: 51687450f95b6d34e83af27dd2902f62, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x

--- a/DEFCON Z/Assets/Prefabs/Units/Zombie.prefab
+++ b/DEFCON Z/Assets/Prefabs/Units/Zombie.prefab
@@ -32,7 +32,7 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 8895272907540564105}
+  - {fileID: 1807248510703030338}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: -90, z: 0}
@@ -50,9 +50,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   objName: Zombie
   health: 100
+  currentZone: {fileID: 0}
   deathSound: {fileID: 8300000, guid: beca4447c7e7c5e4f994c4c88a5e04f9, type: 3}
   RecruitCost: 500
   Upkeep: 0.5
+  unitModel: {fileID: 8940772615325665434}
   navMeshAgent: {fileID: 0}
   audioSource: {fileID: 0}
 --- !u!136 &6693292440879736203
@@ -203,12 +205,43 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+--- !u!1 &8940772615325665434
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1807248510703030338}
+  m_Layer: 0
+  m_Name: UnitModel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1807248510703030338
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8940772615325665434}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 8895272907540564105}
+  m_Father: {fileID: 6693292440879736311}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &8895272907540435467
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 6693292440879736311}
+    m_TransformParent: {fileID: 1807248510703030338}
     m_Modifications:
     - target: {fileID: 100002, guid: 51687450f95b6d34e83af27dd2902f62, type: 3}
       propertyPath: m_Name
@@ -216,7 +249,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 400002, guid: 51687450f95b6d34e83af27dd2902f62, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 400002, guid: 51687450f95b6d34e83af27dd2902f62, type: 3}
       propertyPath: m_LocalPosition.y
@@ -228,7 +261,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 400002, guid: 51687450f95b6d34e83af27dd2902f62, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 400002, guid: 51687450f95b6d34e83af27dd2902f62, type: 3}
       propertyPath: m_LocalRotation.y

--- a/DEFCON Z/Assets/Scripts/GameManager.cs
+++ b/DEFCON Z/Assets/Scripts/GameManager.cs
@@ -113,5 +113,18 @@ namespace DefconZ
                 faction.Difficulty.Value = difficulty.Value;
             }
         }
+
+        /// <summary>
+        /// Removes a unit from active state before deleting.
+        /// </summary>
+        /// <param name="unit"></param>
+        public void RemoveUnit(UnitBase unit, float delay)
+        {
+            GameObject unitGameObject = unit.gameObject;
+            // Remove the unit gamescript from the unit
+            Destroy(unit);
+
+            Destroy(unitGameObject, delay);
+        }
     }
 }

--- a/DEFCON Z/Assets/Scripts/Units/Human.cs
+++ b/DEFCON Z/Assets/Scripts/Units/Human.cs
@@ -1,13 +1,9 @@
-﻿namespace DefconZ
+﻿namespace DefconZ.Units
 {
     public class Human : UnitBase
     {
-        public override void InitUnit()
-        {
-        }
+        public override void InitUnit() { }
 
-        public override void Update()
-        {
-        }
+        public override void Update() { }
     }
 }

--- a/DEFCON Z/Assets/Scripts/Units/UnitBase.cs
+++ b/DEFCON Z/Assets/Scripts/Units/UnitBase.cs
@@ -19,6 +19,8 @@ namespace DefconZ
         public float RecruitCost;
         public float Upkeep;
 
+        public GameObject unitModel;
+
         [SerializeField]
         private NavMeshAgent navMeshAgent;
 
@@ -193,13 +195,22 @@ namespace DefconZ
         /// </summary>
         public virtual void DestroySelf()
         {
-            // Ask the unit to remove itself the current zone
-            currentZone.RemoveFromZone(this);
+            Debug.Log(this.objName + " has reached 0 or less health and has died");
 
-            Debug.Log(this.objName + " has reached 0 or less health and has been destroyed");
-            audioSource.clip = deathSound; // set the audio source clip to the death sound clip
+            // Ask the unit to remove itself the current zone
+            if (currentZone != null)
+            {
+                currentZone.RemoveFromZone(this);
+            }
+            
+            // Rotate the model 
+            unitModel.transform.eulerAngles = new Vector3(90, unitModel.transform.rotation.y, unitModel.transform.rotation.z);
+
+            // set the audio source clip to the death sound clip
+            audioSource.clip = deathSound; 
             audioSource.Play();
-            Destroy(gameObject, deathSound.length); // Remove the game object this script is attached to after the deathsound has finished playing
+
+            _gameManager.RemoveUnit(this, deathSound.length);
         }
 
         /// <summary>

--- a/DEFCON Z/Assets/Scripts/Units/Zombie.cs
+++ b/DEFCON Z/Assets/Scripts/Units/Zombie.cs
@@ -1,4 +1,4 @@
-﻿namespace DefconZ
+﻿namespace DefconZ.Units
 {
     public class Zombie : UnitBase
     {

--- a/DEFCON Z/Assets/Tests/PlayMode Tests/CombatTest.cs
+++ b/DEFCON Z/Assets/Tests/PlayMode Tests/CombatTest.cs
@@ -1,5 +1,6 @@
 ﻿using DefconZ;
 using DefconZ.Simulation;
+using DefconZ.Units;
 using NUnit.Framework;
 using UnityEngine;
 

--- a/DEFCON Z/Assets/Tests/PlayMode Tests/SelectionTest.cs
+++ b/DEFCON Z/Assets/Tests/PlayMode Tests/SelectionTest.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using DefconZ;
+using DefconZ.Units;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;


### PR DESCRIPTION
## Description
Dead units gamecode is removed, and the game manager handles removing the unit from the game.

## Related Issue
Resolves #46 

## Motivation and Context
Dead units acted in the game world after dead until removed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code Refactor (styling fix, extracting methods, etc. Does not cause any functionality changes)
