### PR TITLE
Create IsHostile Extension

### DIFF
--- a/DEFCON Z/Assets/Scripts/Utility/UnitExtensions.cs
+++ b/DEFCON Z/Assets/Scripts/Utility/UnitExtensions.cs
@@ -1,0 +1,25 @@
+﻿namespace DefconZ.Utility
+{
+    public static class UnitExtensions
+    {
+        /// <summary>
+        /// Determines whether the specified other unit is hostile.
+        /// </summary>
+        /// <param name="unit">The unit.</param>
+        /// <param name="otherUnit">The other unit.</param>
+        /// <returns>
+        ///   <c>true</c> if the specified other unit is hostile; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool IsHostile(this UnitBase unit, UnitBase otherUnit)
+        {
+            bool isHostile = false;
+
+            if (unit.FactionOwner != otherUnit.FactionOwner)
+            {
+                isHostile = true;
+            }
+
+            return isHostile;
+        }
+    }
+}

--- a/DEFCON Z/Assets/Scripts/Utility/UnitExtensions.cs.meta
+++ b/DEFCON Z/Assets/Scripts/Utility/UnitExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b1468a8ca8b26a54499a9d677d226e1e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DEFCON Z/Assets/Tests/PlayMode Tests/Unit.meta
+++ b/DEFCON Z/Assets/Tests/PlayMode Tests/Unit.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 344a7b0e63d1a154196cd996b2f32960
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DEFCON Z/Assets/Tests/PlayMode Tests/Unit/UnitExtensionsTest.cs
+++ b/DEFCON Z/Assets/Tests/PlayMode Tests/Unit/UnitExtensionsTest.cs
@@ -1,0 +1,61 @@
+﻿using DefconZ;
+using DefconZ.Units;
+using DefconZ.Utility;
+using NUnit.Framework;
+
+namespace Tests.Unit
+{
+    public class UnitExtensionsTest : BaseTest
+    {
+        /// <summary>
+        /// This test tests whether IsHostile returns true when the two
+        /// compared unit is not of the same faction.
+        /// </summary>
+        [Test]
+        public void IsHostile_Should_Return_True_When_Hostile()
+        {
+            // Arrange
+            var humanFaction = _gameObject.AddComponent<HumanFaction>();
+            var zombieFaction = _gameObject.AddComponent<ZombieFaction>();
+
+            var humanUnit = _gameObject.AddComponent<Human>();
+            humanUnit.FactionOwner = humanFaction;
+
+            var zombieUnit = _gameObject.AddComponent<Zombie>();
+            zombieUnit.FactionOwner = zombieFaction;
+
+            var expected = true;
+
+            // Act
+            var isHostile = humanUnit.IsHostile(zombieUnit);
+
+            // Assert
+            Assert.That(expected, Is.EqualTo(isHostile));
+        }
+
+        /// <summary>
+        /// This test tests whether IsHostile returns true when the two
+        /// compared unit is of the same faction.
+        /// </summary>
+        [Test]
+        public void IsHostile_Should_Return_False_When_NotHostile()
+        {
+            // Arrange
+            var humanFaction = _gameObject.AddComponent<HumanFaction>();
+
+            var humanUnit = _gameObject.AddComponent<Human>();
+            humanUnit.FactionOwner = humanFaction;
+
+            var zombieUnit = _gameObject.AddComponent<Zombie>();
+            zombieUnit.FactionOwner = humanFaction;
+
+            var expected = false;
+
+            // Act
+            var isHostile = humanUnit.IsHostile(zombieUnit);
+
+            // Assert
+            Assert.That(expected, Is.EqualTo(isHostile));
+        }
+    }
+}

--- a/DEFCON Z/Assets/Tests/PlayMode Tests/Unit/UnitExtensionsTest.cs.meta
+++ b/DEFCON Z/Assets/Tests/PlayMode Tests/Unit/UnitExtensionsTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 35322377dbb5bb34b81259c3f58f2e56
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Description
This PR adds `IsHostile` extension method. The method compares two different unit object and determines if it is a hostile or friendly unit.

## Motivation and Context
To increase code reusability.

## How Has This Been Tested?
A new test has been created.

## Screenshots (when applicable):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code Refactor (styling fix, extracting methods, etc. Does not cause any functionality changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
