### PR TITLE
Refactor Resource Class

### DIFF
--- a/DEFCON Z/Assets/Scripts/GameLevel/Zone.cs
+++ b/DEFCON Z/Assets/Scripts/GameLevel/Zone.cs
@@ -128,7 +128,7 @@ namespace DefconZ.GameLevel
                 if (zoneOwner != null)
                 {
                     // Remove the resource cap boost for the owner of the zone
-                    zoneOwner.Resource.MaxResourcePoint -= zoneResourceValue;
+                    zoneOwner.Resource.OwnedZones.Remove(this);
                 }
 
                 // Assign the new zone owner
@@ -138,7 +138,7 @@ namespace DefconZ.GameLevel
                 if (zoneOwner != null)
                 {
                     // Add the resource cap boost to the new owner
-                    zoneOwner.Resource.MaxResourcePoint += zoneResourceValue;
+                    zoneOwner.Resource.OwnedZones.Add(this);
                 }
 
                 // Update the display color of the zone

--- a/DEFCON Z/Assets/Scripts/GameManager.cs
+++ b/DEFCON Z/Assets/Scripts/GameManager.cs
@@ -108,9 +108,20 @@ namespace DefconZ
         {
             foreach (var faction in Factions)
             {
+                var modValue = difficulty.Value;
+
+                // If it is not player's faction, negate the modifier value
+                // so it has an opposite effect. For example on easy
+                // difficulty with modifier value of 0.5f will make player's
+                // faction stronger but will cripple the AI's Faction.
+                if (!faction.IsPlayerUnit)
+                {
+                    modValue *= -1;
+                }
+
                 faction.Difficulty.Name = difficulty.Name;
                 faction.Difficulty.Type = difficulty.Type;
-                faction.Difficulty.Value = difficulty.Value;
+                faction.Difficulty.Value = modValue;
             }
         }
 

--- a/DEFCON Z/Assets/Scripts/GameManager.cs
+++ b/DEFCON Z/Assets/Scripts/GameManager.cs
@@ -94,7 +94,7 @@ namespace DefconZ
                 Debug.Log($"Gathered {resourceGathered} amount of resource.");
                 Debug.Log($"Maintenance cost at {maintenanceCost}");
 
-                Debug.Log($"{faction.FactionName} has {faction.Resource.ResourcePoint} amount of resources.");
+                Debug.Log($"{faction.FactionName} has {faction.Resource.ResourcePoint} amount of resources out of {faction.Resource.MaxResourcePoint}.");
             }
 
             Debug.Log("Game day elapsed " + _clock.GameDay);

--- a/DEFCON Z/Assets/Scripts/GameManager.cs
+++ b/DEFCON Z/Assets/Scripts/GameManager.cs
@@ -94,7 +94,7 @@ namespace DefconZ
                 Debug.Log($"Gathered {resourceGathered} amount of resource.");
                 Debug.Log($"Maintenance cost at {maintenanceCost}");
 
-                Debug.Log($"{faction.FactionName} has {faction.Resource.ResourcePoint} amount of resources out of {faction.Resource.MaxResourcePoint}.");
+                Debug.Log($"{faction.FactionName} has {faction.Resource.ResourcePoint} amount of resources out of {faction.Resource.GetMaxResourcePoint}.");
             }
 
             Debug.Log("Game day elapsed " + _clock.GameDay);

--- a/DEFCON Z/Assets/Scripts/Simulation/Resource.cs
+++ b/DEFCON Z/Assets/Scripts/Simulation/Resource.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using DefconZ.GameLevel;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -11,7 +12,6 @@ namespace DefconZ.Simulation
     public class Resource
     {
         public float BaseResourcePoint { get; }
-        public float MaxResourcePoint { get; set; }
 
         public float MaxResourcePoint
         {
@@ -25,21 +25,27 @@ namespace DefconZ.Simulation
         public float SciencePoint { get; set; }
         public float ResourcePoint { get; set; }
 
-        public IList<Modifier> Modifiers { get; }
         public ICollection<Modifier> Modifiers { get; }
+
+        public ICollection<Zone> OwnedZones { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Resource"/> class.
         /// </summary>
+        [Obsolete("Use Resource(ICollection) for Constructor or the game breaks.")]
         public Resource()
         {
             BaseResourcePoint = 10000.0f;
             Modifiers = new List<Modifier>();
+            OwnedZones = new List<Zone>();
         }
+
         public Resource(ICollection<Modifier> modifiers)
         {
             BaseResourcePoint = 10000.0f;
             Modifiers = modifiers;
+            OwnedZones = new List<Zone>();
+
             ComputeStartingValue();
         }
 

--- a/DEFCON Z/Assets/Scripts/Simulation/Resource.cs
+++ b/DEFCON Z/Assets/Scripts/Simulation/Resource.cs
@@ -17,6 +17,7 @@ namespace DefconZ.Simulation
         public float ResourcePoint { get; set; }
 
         public IList<Modifier> Modifiers { get; }
+        public ICollection<Modifier> Modifiers { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Resource"/> class.
@@ -26,11 +27,18 @@ namespace DefconZ.Simulation
             BaseResourcePoint = 10000.0f;
             Modifiers = new List<Modifier>();
         }
+        public Resource(ICollection<Modifier> modifiers)
+        {
+            BaseResourcePoint = 10000.0f;
+            Modifiers = modifiers;
+            ComputeStartingValue();
+        }
 
         /// <summary>
         /// Computes the starting resource value.
         /// </summary>
         public Resource ComputeStartingValue()
+        private Resource ComputeStartingValue()
         {
             Debug.Log("Calculating starting resources.");
 

--- a/DEFCON Z/Assets/Scripts/Simulation/Resource.cs
+++ b/DEFCON Z/Assets/Scripts/Simulation/Resource.cs
@@ -30,7 +30,7 @@ namespace DefconZ.Simulation
         public float SciencePoint { get; set; }
         public float ResourcePoint { get; set; }
 
-        public ICollection<Modifier> Modifiers { get; }
+        private ICollection<Modifier> Modifiers { get; }
 
         public ICollection<Zone> OwnedZones { get; }
 

--- a/DEFCON Z/Assets/Scripts/Simulation/Resource.cs
+++ b/DEFCON Z/Assets/Scripts/Simulation/Resource.cs
@@ -1,5 +1,4 @@
 ﻿using DefconZ.GameLevel;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -13,6 +12,12 @@ namespace DefconZ.Simulation
     {
         public float BaseResourcePoint { get; }
 
+        /// <summary>
+        /// Gets the maximum resource point.
+        /// </summary>
+        /// <value>
+        /// The maximum resource point.
+        /// </value>
         public float MaxResourcePoint
         {
             get
@@ -69,7 +74,7 @@ namespace DefconZ.Simulation
         }
 
         /// <summary>
-        /// Calculates the maximum points available.
+        /// Calculates the maximum available resource points.
         /// </summary>
         private float CalculateMaxPoints()
         {
@@ -82,7 +87,7 @@ namespace DefconZ.Simulation
         /// <summary>
         /// Computes the gain/loss in resources.
         /// </summary>
-        /// <returns>Resource gathered</returns>
+        /// <returns>Resource gathered.</returns>
         public float GatherResource()
         {
             // Base resource replenish resource point from zero to full in

--- a/DEFCON Z/Assets/Scripts/Simulation/Resource.cs
+++ b/DEFCON Z/Assets/Scripts/Simulation/Resource.cs
@@ -87,7 +87,7 @@ namespace DefconZ.Simulation
             var modifierValue = 1.0f + Modifiers.Sum(mod => mod.Value);
             var totalOwnedZones = OwnedZones.Sum(v => v.zoneResourceValue);
 
-            return (BaseResourcePoint * modifierValue) + totalOwnedZones;
+            return (BaseResourcePoint + totalOwnedZones) * modifierValue;
         }
 
         /// <summary>

--- a/DEFCON Z/Assets/Scripts/Simulation/Resource.cs
+++ b/DEFCON Z/Assets/Scripts/Simulation/Resource.cs
@@ -29,17 +29,6 @@ namespace DefconZ.Simulation
 
         public ICollection<Zone> OwnedZones { get; }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Resource"/> class.
-        /// </summary>
-        [Obsolete("Use Resource(ICollection) for Constructor or the game breaks.")]
-        public Resource()
-        {
-            BaseResourcePoint = 10000.0f;
-            Modifiers = new List<Modifier>();
-            OwnedZones = new List<Zone>();
-        }
-
         public Resource(ICollection<Modifier> modifiers)
         {
             BaseResourcePoint = 10000.0f;

--- a/DEFCON Z/Assets/Scripts/Simulation/Resource.cs
+++ b/DEFCON Z/Assets/Scripts/Simulation/Resource.cs
@@ -12,6 +12,15 @@ namespace DefconZ.Simulation
     {
         public float BaseResourcePoint { get; }
         public float MaxResourcePoint { get; set; }
+
+        public float MaxResourcePoint
+        {
+            get
+            {
+                return CalculateMaxPoints();
+            }
+        }
+
         public float MaxSciencePoint { get; set; }
         public float SciencePoint { get; set; }
         public float ResourcePoint { get; set; }
@@ -37,7 +46,6 @@ namespace DefconZ.Simulation
         /// <summary>
         /// Computes the starting resource value.
         /// </summary>
-        public Resource ComputeStartingValue()
         private Resource ComputeStartingValue()
         {
             Debug.Log("Calculating starting resources.");
@@ -68,13 +76,12 @@ namespace DefconZ.Simulation
         /// <summary>
         /// Calculates the maximum points available.
         /// </summary>
-        public Resource CalculateMaxPoints()
+        private float CalculateMaxPoints()
         {
             var modifierValue = 1.0f + Modifiers.Sum(mod => mod.Value);
+            var totalOwnedZones = OwnedZones.Sum(v => v.zoneResourceValue);
 
-            MaxResourcePoint = BaseResourcePoint * modifierValue;
-
-            return this;
+            return (BaseResourcePoint * modifierValue) + totalOwnedZones;
         }
 
         /// <summary>

--- a/DEFCON Z/Assets/Scripts/Simulation/Resource.cs
+++ b/DEFCON Z/Assets/Scripts/Simulation/Resource.cs
@@ -18,7 +18,7 @@ namespace DefconZ.Simulation
         /// <value>
         /// The maximum resource point.
         /// </value>
-        public float MaxResourcePoint
+        public float GetMaxResourcePoint
         {
             get
             {
@@ -66,7 +66,7 @@ namespace DefconZ.Simulation
 
             var resourceModValue = 0.3f + diffModValue + UnityEngine.Random.Range(0.05f, 0.1f);
 
-            ResourcePoint = resourceModValue * MaxResourcePoint;
+            ResourcePoint = resourceModValue * GetMaxResourcePoint;
 
             Debug.Log("End starting resources.");
 
@@ -92,16 +92,16 @@ namespace DefconZ.Simulation
         {
             // Base resource replenish resource point from zero to full in
             // 3 years or 1095 days.
-            float baseresourcePointIncrease = MaxResourcePoint / 1095.0f;
+            float baseresourcePointIncrease = GetMaxResourcePoint / 1095.0f;
             float increaseModifier = 1.0f + Modifiers.Sum(mod => mod.Value);
             float resourcePointIncrease = baseresourcePointIncrease * increaseModifier;
 
             ResourcePoint += resourcePointIncrease;
 
             // Limit the available resource point to MaxResourcePoint.
-            if (ResourcePoint > MaxResourcePoint)
+            if (ResourcePoint > GetMaxResourcePoint)
             {
-                ResourcePoint = MaxResourcePoint;
+                ResourcePoint = GetMaxResourcePoint;
             }
 
             return resourcePointIncrease;

--- a/DEFCON Z/Assets/Scripts/UI/PlayerUI.cs
+++ b/DEFCON Z/Assets/Scripts/UI/PlayerUI.cs
@@ -53,7 +53,7 @@ namespace DefconZ.UI
         public void InitUI(Faction playerFaction)
         {
             this.playerFaction = playerFaction;
-            pointStatus.InitSliderBar(playerFaction.Resource.MaxResourcePoint, 0.0f);
+            pointStatus.InitSliderBar(playerFaction.Resource.GetMaxResourcePoint, 0.0f);
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace DefconZ.UI
         {
             if (playerFaction != null)
             {
-                pointStatus.UpdateSlider(playerFaction.Resource.ResourcePoint, playerFaction.Resource.MaxResourcePoint);
+                pointStatus.UpdateSlider(playerFaction.Resource.ResourcePoint, playerFaction.Resource.GetMaxResourcePoint);
             }
         }
 

--- a/DEFCON Z/Assets/Scripts/Units/Faction.cs
+++ b/DEFCON Z/Assets/Scripts/Units/Faction.cs
@@ -29,8 +29,6 @@ namespace DefconZ.Units
             // Reference difficulty modifier.
             Resource.Modifiers.Add(Difficulty);
 
-            Resource.CalculateMaxPoints()
-                    .ComputeStartingValue();
 
             Debug.Log(FactionName + " faction has Max Resource Point of " + Resource.MaxResourcePoint);
             Debug.Log(FactionName + " faction has Starting Resource Point of " + Resource.ResourcePoint);

--- a/DEFCON Z/Assets/Scripts/Units/Faction.cs
+++ b/DEFCON Z/Assets/Scripts/Units/Faction.cs
@@ -28,7 +28,7 @@ namespace DefconZ.Units
             // Reference difficulty modifier.
             Modifiers.Add(Difficulty);
 
-            Debug.Log(FactionName + " faction has Max Resource Point of " + Resource.MaxResourcePoint);
+            Debug.Log(FactionName + " faction has Max Resource Point of " + Resource.GetMaxResourcePoint);
             Debug.Log(FactionName + " faction has Starting Resource Point of " + Resource.ResourcePoint);
 
             InitAwake();

--- a/DEFCON Z/Assets/Scripts/Units/Faction.cs
+++ b/DEFCON Z/Assets/Scripts/Units/Faction.cs
@@ -16,19 +16,17 @@ namespace DefconZ.Units
         public GameObject UnitSpawnPoint;
 
         public Modifier Difficulty = Simulation.Difficulty.Normal;
+        public ICollection<Modifier> Modifiers;
 
         private void Awake()
         {
             Units = new List<GameObject>();
             Level = new Level();
-            Resource = new Resource();
-
-            // Reference the faction level to the resource calculation.
-            Resource.Modifiers.Add(Level.LevelModifier);
+            Modifiers = new List<Modifier>();
+            Resource = new Resource(Modifiers);
 
             // Reference difficulty modifier.
-            Resource.Modifiers.Add(Difficulty);
-
+            Modifiers.Add(Difficulty);
 
             Debug.Log(FactionName + " faction has Max Resource Point of " + Resource.MaxResourcePoint);
             Debug.Log(FactionName + " faction has Starting Resource Point of " + Resource.ResourcePoint);

--- a/DEFCON Z/Assets/Tests/PlayMode Tests/ResourceTest.cs
+++ b/DEFCON Z/Assets/Tests/PlayMode Tests/ResourceTest.cs
@@ -13,8 +13,7 @@ namespace Tests
         {
             // Arrange
             Resource resource = new Resource();
-            resource.CalculateMaxPoints()
-                    .ComputeStartingValue();
+            resource.ComputeStartingValue();
 
             // Increase resource recovery rate by huge amount.
             resource.Modifiers.Add(new Modifier
@@ -65,10 +64,10 @@ namespace Tests
             resource.Modifiers.Add(mod2);
 
             // Act
-            resource.CalculateMaxPoints();
+            float actualMaxResourcePoint = resource.MaxResourcePoint;
 
             // Assert
-            Assert.That(expectedMaxValue, Is.EqualTo(resource.MaxResourcePoint));
+            Assert.That(expectedMaxValue, Is.EqualTo(actualMaxResourcePoint));
         }
 
         [Test]
@@ -92,22 +91,20 @@ namespace Tests
                 Value = 0.3f
             };
 
-            resource.CalculateMaxPoints()
-                    .ComputeStartingValue();
-
-            float expectedIncrease = resource.MaxResourcePoint / 1095.0f * 1.8f;
-
             // The additional modifier value will increase the gathering value
             // from its base value by 80 percent.
             resource.Modifiers.Add(mod);
             resource.Modifiers.Add(mod2);
 
+            resource.ComputeStartingValue();
+
+            float expectedIncrease = resource.MaxResourcePoint / 1095.0f * 1.8f;
+
             // Act
             float startingResource = resource.ResourcePoint;
-            resource.GatherResource();
+            var actualIncrease = resource.GatherResource();
 
             // Assert
-            var actualIncrease = resource.ResourcePoint - startingResource;
             Assert.That(expectedIncrease, Is.EqualTo(actualIncrease).Within(margin));
         }
     }

--- a/DEFCON Z/Assets/Tests/PlayMode Tests/ResourceTest.cs
+++ b/DEFCON Z/Assets/Tests/PlayMode Tests/ResourceTest.cs
@@ -59,7 +59,7 @@ namespace Tests
             }
 
             // Assert
-            Assert.That(resource.MaxResourcePoint, Is.EqualTo(resource.ResourcePoint));
+            Assert.That(resource.GetMaxResourcePoint, Is.EqualTo(resource.ResourcePoint));
         }
 
         /// <summary>
@@ -92,7 +92,7 @@ namespace Tests
             Modifiers.Add(mod2);
 
             // Act
-            float actualMaxResourcePoint = resource.MaxResourcePoint;
+            float actualMaxResourcePoint = resource.GetMaxResourcePoint;
 
             // Assert
             Assert.That(expectedMaxValue, Is.EqualTo(actualMaxResourcePoint));
@@ -123,7 +123,7 @@ namespace Tests
             Modifiers.Add(mod);
             Modifiers.Add(mod2);
 
-            float expectedIncrease = resource.MaxResourcePoint / 1095.0f * 1.8f;
+            float expectedIncrease = resource.GetMaxResourcePoint / 1095.0f * 1.8f;
 
             // Act
             float startingResource = resource.ResourcePoint;

--- a/DEFCON Z/Assets/Tests/PlayMode Tests/ResourceTest.cs
+++ b/DEFCON Z/Assets/Tests/PlayMode Tests/ResourceTest.cs
@@ -1,10 +1,42 @@
 ﻿using DefconZ.Simulation;
 using NUnit.Framework;
+using System.Collections.Generic;
 
 namespace Tests
 {
     public class ResourceTest
     {
+        protected Resource resource;
+        protected ICollection<Modifier> Modifiers;
+
+        /// <summary>
+        /// Sets up test on first test initiation..
+        /// </summary>
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            Modifiers = new List<Modifier>();
+        }
+
+        /// <summary>
+        /// Sets up data before each test.
+        /// </summary>
+        [SetUp]
+        public void SetUp()
+        {
+            resource = new Resource(Modifiers);
+        }
+
+        /// <summary>
+        /// Clean up data after each test.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            Modifiers.Clear();
+            resource = null;
+        }
+
         /// <summary>
         /// Resources should not exceed maximum when being gathered.
         /// </summary>
@@ -12,10 +44,9 @@ namespace Tests
         public void Resource_ShouldNot_Exceed_Max()
         {
             // Arrange
-            Resource resource = new Resource();
 
             // Increase resource recovery rate by huge amount.
-            resource.Modifiers.Add(new Modifier
+            Modifiers.Add(new Modifier
             {
                 Value = 1000
             });
@@ -41,8 +72,6 @@ namespace Tests
             // Arrange
             float expectedMaxValue = 18000.0f;
 
-            Resource resource = new Resource();
-
             Modifier mod = new Modifier
             {
                 Name = "Test Modifier",
@@ -59,8 +88,8 @@ namespace Tests
 
             // The additional modifier value will increase the max value
             // from its base value by 80 percent.
-            resource.Modifiers.Add(mod);
-            resource.Modifiers.Add(mod2);
+            Modifiers.Add(mod);
+            Modifiers.Add(mod2);
 
             // Act
             float actualMaxResourcePoint = resource.MaxResourcePoint;
@@ -73,7 +102,6 @@ namespace Tests
         public void Resource_GatherResource_Should_Follow_Modifiers()
         {
             // Arrange
-            Resource resource = new Resource();
             float margin = 0.001f;
 
             Modifier mod = new Modifier
@@ -92,8 +120,8 @@ namespace Tests
 
             // The additional modifier value will increase the gathering value
             // from its base value by 80 percent.
-            resource.Modifiers.Add(mod);
-            resource.Modifiers.Add(mod2);
+            Modifiers.Add(mod);
+            Modifiers.Add(mod2);
 
             float expectedIncrease = resource.MaxResourcePoint / 1095.0f * 1.8f;
 

--- a/DEFCON Z/Assets/Tests/PlayMode Tests/ResourceTest.cs
+++ b/DEFCON Z/Assets/Tests/PlayMode Tests/ResourceTest.cs
@@ -13,7 +13,6 @@ namespace Tests
         {
             // Arrange
             Resource resource = new Resource();
-            resource.ComputeStartingValue();
 
             // Increase resource recovery rate by huge amount.
             resource.Modifiers.Add(new Modifier
@@ -95,8 +94,6 @@ namespace Tests
             // from its base value by 80 percent.
             resource.Modifiers.Add(mod);
             resource.Modifiers.Add(mod2);
-
-            resource.ComputeStartingValue();
 
             float expectedIncrease = resource.MaxResourcePoint / 1095.0f * 1.8f;
 

--- a/DEFCON Z/Assets/Tests/PlayMode Tests/ResourceTest.cs
+++ b/DEFCON Z/Assets/Tests/PlayMode Tests/ResourceTest.cs
@@ -68,7 +68,6 @@ namespace Tests
             resource.CalculateMaxPoints();
 
             // Assert
-            Assert.AreEqual(expectedMaxValue, resource.MaxResourcePoint);
             Assert.That(expectedMaxValue, Is.EqualTo(resource.MaxResourcePoint));
         }
 


### PR DESCRIPTION
## Description
Refactor for `Resource` class.

Previously, to initialize `Resource` class, the caller needs to call both `CalculateMaxPoint()` and `ComputeStartingValue()` in their respective order. The Maximum Resource Point will be stored in the `MaxResourcePoint` property  . The property is both read and write property. This may posses a problem further down the line if any code that modifies the value manually. The maximum resource point have its own calculation based on many external factor.

This PR removes the need to call the "init" method for the caller but now require the caller to pass in a `Modifer` List. For this particular case, the lists of modifiers will be given by the `Faction` class. As the game progresses, the `Faction` class will handle the modifiers that will be passed into the `Resource` instance. In addition, `MaxResourcePoint` is changed to `GetMaxResourcePoint` read only property and will recalculate the latest state. I also added references to `Zone` owned.

This PR also tweak difficulty modifier. The AI and Player will have an opposite modifier. For e.g for *Hard* mode, player will be 50 percent less effective and the AI will be 50 percent more efficient.

## Motivation and Context
This refactor aims to reduce code error and adds more flexibility to the architecture.

## How Has This Been Tested?
Tests has been modified to use the new system.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code Refactor (styling fix, extracting methods, etc. Does not cause any functionality changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
