### PR TITLE
Enable Force Recruit Unit

### DIFF
--- a/DEFCON Z/Assets/Scripts/GameManager.cs
+++ b/DEFCON Z/Assets/Scripts/GameManager.cs
@@ -45,9 +45,6 @@ namespace DefconZ
             Factions.Add(humanFaction);
             Factions.Add(zombieFaction);
 
-            humanFaction.RecruitUnit();
-            zombieFaction.RecruitUnit();
-
             _clock.GameCycleElapsed += Clock_GameCycleElapsed;
             _clock.GameCycleElapsed += Combat;
 

--- a/DEFCON Z/Assets/Scripts/UI/PlayerUI.cs
+++ b/DEFCON Z/Assets/Scripts/UI/PlayerUI.cs
@@ -199,7 +199,7 @@ namespace DefconZ.UI
 		/// </summary>
 		public void PurchaseUnitAction()
         {
-            playerFaction.RecruitUnit();
+            playerFaction.ForceRecruitUnit();
         }
 
         /// <summary>

--- a/DEFCON Z/Assets/Scripts/Units/Faction.cs
+++ b/DEFCON Z/Assets/Scripts/Units/Faction.cs
@@ -85,6 +85,7 @@ namespace DefconZ.Units
         /// </summary>
         protected virtual void InitStart()
         {
+            ForceRecruitUnit();
         }
 
         /// <summary>
@@ -104,13 +105,15 @@ namespace DefconZ.Units
         }
 
         /// <summary>
-        /// Recruits a new unit when there is enough resource for the
-        /// faction.
+        /// Recruit unit by bypassing resources and build time.
+        /// Only for initializing.
         /// </summary>
-        [Obsolete("This method will be deprecated, use RecruitUnitAt(Vector3)")]
-        public void RecruitUnit()
+        private void ForceRecruitUnit()
         {
-            RecruitUnitAt(UnitSpawnPoint.transform.position);
+            var recruitedUnit = Instantiate(UnitPrefab, UnitSpawnPoint.transform.position, Quaternion.identity);
+            recruitedUnit.GetComponent<UnitBase>().FactionOwner = this;
+
+            Units.Add(recruitedUnit);
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
This PR deprecates `RecruitAt()` and replaces it with `ForceRecruitUnit()`. The method is used to give a unit for a faction to start with without having to expend resource point or wait for the build to finish.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code Refactor (styling fix, extracting methods, etc. Does not cause any functionality changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
