### PR TITLE
Victory Screen Unit Test

### DIFF
--- a/DEFCON Z/Assets/Tests/PlayMode Tests/VictoryScreenTest.cs
+++ b/DEFCON Z/Assets/Tests/PlayMode Tests/VictoryScreenTest.cs
@@ -27,8 +27,9 @@ namespace Tests
         {
             SceneManager.UnloadSceneAsync(SceneManager.GetActiveScene());
         }
+        
         /// <summary>
-        /// Tests Victory screen being initialized correctly.
+        /// Victory Screen should be inactive when initialized 
         /// </summary>
         [Test]
         public void VictoryScreen_Should_Be_Initialize_Correctly()
@@ -42,13 +43,17 @@ namespace Tests
             //Assert
             Assert.That(victoryScreen.gameObject.activeSelf, Is.EqualTo(expected));
         }
+        
         /// <summary>
-        /// Tests whether the display victory gets set to active.
+        /// Tests whether victory screen gets set to active.
         /// </summary>
         /// <returns></returns>
         [UnityTest]
         public IEnumerator DisplayVictory_Should_Set_Object_To_Active()
         {
+            yield return null;
+            
+            // Assert 
             bool expected = true;
 
             var gameManager = GameObject.FindGameObjectWithTag(nameof(GameManager));
@@ -63,8 +68,6 @@ namespace Tests
 
             // Assert 
             Assert.That(victoryScreen.isActiveAndEnabled, Is.EqualTo(expected));
-
-            yield return null;
         }
     }
 }

--- a/DEFCON Z/Assets/Tests/PlayMode Tests/VictoryScreenTest.cs
+++ b/DEFCON Z/Assets/Tests/PlayMode Tests/VictoryScreenTest.cs
@@ -41,9 +41,11 @@ namespace Tests
 
             //Assert
             Assert.That(victoryScreen.gameObject.activeSelf, Is.EqualTo(expected));
-
         }
-        /// Tests whether the victory display gets set to active.
+        /// <summary>
+        /// Tests whether the display victory gets set to active.
+        /// </summary>
+        /// <returns></returns>
         [UnityTest]
         public IEnumerator DisplayVictory_Should_Set_Object_To_Active()
         {

--- a/DEFCON Z/Assets/Tests/PlayMode Tests/VictoryScreenTest.cs
+++ b/DEFCON Z/Assets/Tests/PlayMode Tests/VictoryScreenTest.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using DefconZ;
+using DefconZ.UI;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.TestTools;
+using UnityEngine.UI;
+
+namespace Tests
+{
+    public class VictoryScreenTest : BaseTest
+    {
+        /// <summary>
+        /// Setup test data for each specific test
+        /// </summary>
+        [SetUp]
+        public void TestInit()
+        {
+            SceneManager.LoadScene("Defcon city", LoadSceneMode.Single);
+        }
+        /// <summary>
+        /// Cleans up after each test.
+        /// </summary>
+        public void TestCleanUp()
+        {
+            SceneManager.UnloadSceneAsync(SceneManager.GetActiveScene());
+        }
+        /// <summary>
+        /// Tests Victory screen being initialized correctly.
+        /// </summary>
+        [Test]
+        public void VictoryScreen_Should_Be_Initialize_Correctly()
+        {
+            // Assert
+            bool expected = false;
+
+            // Act
+            var victoryScreen = _gameObject.AddComponent<VictoryScreen>();
+
+            //Assert
+            Assert.That(victoryScreen.gameObject.activeSelf, Is.EqualTo(expected));
+
+        }
+        /// Tests whether the victory display gets set to active.
+        [UnityTest]
+        public IEnumerator DisplayVictory_Should_Set_Object_To_Active()
+        {
+            bool expected = true;
+
+            var gameManager = GameObject.FindGameObjectWithTag(nameof(GameManager));
+            var faction = gameManager.GetComponent<GameManager>().Factions[0];
+
+            var victoryScreen = gameManager.AddComponent<VictoryScreen>();
+            victoryScreen.description = gameManager.AddComponent<Text>();
+            victoryScreen.winnerLabel = victoryScreen.description;
+
+            // Act 
+            victoryScreen.DisplayVictory(faction, faction);
+
+            // Assert 
+            Assert.That(victoryScreen.isActiveAndEnabled, Is.EqualTo(expected));
+
+            yield return null;
+        }
+    }
+}

--- a/DEFCON Z/Assets/Tests/PlayMode Tests/VictoryScreenTest.cs.meta
+++ b/DEFCON Z/Assets/Tests/PlayMode Tests/VictoryScreenTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f2e9ee2c937871341a1d186350bdc1a5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Description
This test implementation checks whether the display victory is set to active as well as test 
whether display victory is initialized correctly. 
## Related Issue
Unit-Test for Victory Screen

## How Has This Been Tested?
Testing was done within Unity and behavior is as intended. 

## Screenshots (when applicable):
![image](https://user-images.githubusercontent.com/48932683/58860900-4db5fc00-8701-11e9-8669-a7844d4d832a.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
