### PR TITLE
Fix Bug #142

### DIFF
--- a/DEFCON Z/Assets/Scripts/GameManager.cs
+++ b/DEFCON Z/Assets/Scripts/GameManager.cs
@@ -182,9 +182,14 @@ namespace DefconZ
                     modValue *= -1;
                 }
 
-                faction.Difficulty.Name = difficulty.Name;
-                faction.Difficulty.Type = difficulty.Type;
-                faction.Difficulty.Value = modValue;
+                var selectedDifficulty = new Modifier
+                {
+                    Name = difficulty.Name,
+                    Type = difficulty.Type,
+                    Value = modValue
+                };
+
+                faction.RegisterDifficulty(selectedDifficulty);
             }
         }
 

--- a/DEFCON Z/Assets/Scripts/Simulation/Difficulty.cs
+++ b/DEFCON Z/Assets/Scripts/Simulation/Difficulty.cs
@@ -1,4 +1,5 @@
-﻿using DefconZ.Simulation;
+﻿using System;
+using DefconZ.Simulation;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -14,7 +15,7 @@ namespace DefconZ.Simulation
         {
             Name = "Easy Difficulty",
             Type = ModifierType.Difficulty,
-            Value = 1.0f
+            Value = 0.5f
         };
 
         public static Modifier Normal = new Modifier

--- a/DEFCON Z/Assets/Scripts/Units/Faction.cs
+++ b/DEFCON Z/Assets/Scripts/Units/Faction.cs
@@ -19,7 +19,6 @@ namespace DefconZ.Units
         public Level Level { get; set; }
         public GameObject UnitSpawnPoint;
 
-        public Modifier Difficulty = Simulation.Difficulty.Normal;
         public ICollection<Modifier> Modifiers;
 
         public UnitBuilder unitBuilder;
@@ -31,9 +30,6 @@ namespace DefconZ.Units
             Modifiers = new List<Modifier>();
             Resource = new Resource(Modifiers);
             unitBuilder = gameObject.AddComponent<UnitBuilder>();
-
-            // Reference difficulty modifier.
-            Modifiers.Add(Difficulty);
 
             Debug.Log(FactionName + " faction has Max Resource Point of " + Resource.GetMaxResourcePoint);
             Debug.Log(FactionName + " faction has Starting Resource Point of " + Resource.ResourcePoint);
@@ -61,7 +57,7 @@ namespace DefconZ.Units
 
         public void SpawnFactionUnit(GameObject prefab, Vector3 spawnPoint)
         {
-             var newUnit = Instantiate(prefab, spawnPoint, Quaternion.identity);
+            var newUnit = Instantiate(prefab, spawnPoint, Quaternion.identity);
             newUnit.GetComponent<UnitBase>().FactionOwner = this;
             Units.Add(newUnit);
         }

--- a/DEFCON Z/Assets/Scripts/Units/Faction.cs
+++ b/DEFCON Z/Assets/Scripts/Units/Faction.cs
@@ -191,5 +191,19 @@ namespace DefconZ.Units
 
             return cost;
         }
+
+        /// <summary>
+        /// Registers the difficulty.
+        /// </summary>
+        /// <remarks>
+        /// Method should only be called once. This method does not check if
+        /// `difficulty` modifier is present. We do not expected this to change
+        /// as we do not allow changing of difficulty mid game.
+        /// </remarks>
+        /// <param name="difficulty">The difficulty.</param>
+        public void RegisterDifficulty(Modifier difficulty)
+        { 
+            Modifiers.Add(difficulty);
+        }
     }
 }

--- a/DEFCON Z/Assets/Scripts/Units/Faction.cs
+++ b/DEFCON Z/Assets/Scripts/Units/Faction.cs
@@ -197,7 +197,7 @@ namespace DefconZ.Units
         /// </summary>
         /// <remarks>
         /// Method should only be called once. This method does not check if
-        /// `difficulty` modifier is present. We do not expected this to change
+        /// `difficulty` modifier is present. We do not expect this to change
         /// as we do not allow changing of difficulty mid game.
         /// </remarks>
         /// <param name="difficulty">The difficulty.</param>


### PR DESCRIPTION
## Description
- Reduce 'Easy' difficulty modifier from 1.0 to 0.5.
- Remove direct reference for `SelectedDifficulty`.
- Register difficulty to each faction when the game is first started. We do not allow changes to difficulty when the game has loaded.

## Related Issue
Closes #142 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code Refactor (styling fix, extracting methods, etc. Does not cause any functionality changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
